### PR TITLE
feat: add Google Workspace CLI to agent image

### DIFF
--- a/komputer-agent/Dockerfile
+++ b/komputer-agent/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Claude Code CLI
-RUN npm install -g @anthropic-ai/claude-code
+# Install Claude Code CLI and Google Workspace CLI
+RUN npm install -g @anthropic-ai/claude-code @googleworkspace/cli
 
 # Install Python dependencies
 WORKDIR /app

--- a/komputer-api/prompt.go
+++ b/komputer-api/prompt.go
@@ -28,6 +28,9 @@ You can install packages — they persist across tasks on this agent:
 ## OAuth
 If OAuth is needed, generate the auth URL, ask the user to open it in their browser and paste back the redirect URL/code. Store tokens in your workspace for reuse.
 
+## Google Workspace
+The ` + "`" + `gws` + "`" + ` CLI is available for Google services (Calendar, Gmail, Drive, Sheets, Docs, Chat, Admin). Use it instead of raw API calls when possible. Run ` + "`" + `gws --help` + "`" + ` or ` + "`" + `gws <service> --help` + "`" + ` to discover commands. It outputs structured JSON.
+
 ## Git Operations
 If your task involves git operations on a private repo:
 - Use SECRET_GITHUB (or the relevant token) in the clone URL: git clone https://{token}@github.com/owner/repo.git


### PR DESCRIPTION
## Summary
- Adds `@googleworkspace/cli` (gws) to the agent Docker image for native Google Workspace access
- Instructs agents via system prompt to prefer `gws` over raw API calls for Calendar, Gmail, Drive, Sheets, Docs, Chat, Admin

## Test plan
- [x] Build agent image and verify `gws --help` works inside pod
- [x] Test agent using `gws` for Google Calendar access

🤖 Generated with [Claude Code](https://claude.com/claude-code)
