### PR TITLE
fix(helm): add RBAC for offices and schedules

### DIFF
--- a/helm/komputer-ai/templates/komputer-operator/rbac.yaml
+++ b/helm/komputer-ai/templates/komputer-operator/rbac.yaml
@@ -22,6 +22,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get
@@ -50,6 +56,58 @@ rules:
   - komputer.komputer.ai
   resources:
   - komputeragents/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - komputer.komputer.ai
+  resources:
+  - komputeroffices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - komputer.komputer.ai
+  resources:
+  - komputeroffices/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - komputer.komputer.ai
+  resources:
+  - komputeroffices/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - komputer.komputer.ai
+  resources:
+  - komputerschedules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - komputer.komputer.ai
+  resources:
+  - komputerschedules/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - komputer.komputer.ai
+  resources:
+  - komputerschedules/status
   verbs:
   - get
   - patch


### PR DESCRIPTION
## Summary
- Add RBAC permissions for KomputerOffice and KomputerSchedule resources to operator ClusterRole
- Add pods/exec permission for execInPod fallback

## Test plan
- [ ] Deploy via Helm — operator starts without RBAC errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
