### PR TITLE
feat: show agent instructions in UI info tab

### DIFF
--- a/komputer-api/handler.go
+++ b/komputer-api/handler.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	komputerv1alpha1 "github.com/komputer-ai/komputer-operator/api/v1alpha1"
@@ -35,8 +36,21 @@ type AgentResponse struct {
 	Lifecycle       string   `json:"lifecycle,omitempty"`
 	LastTaskCostUSD string   `json:"lastTaskCostUSD,omitempty"`
 	TotalCostUSD    string   `json:"totalCostUSD,omitempty"`
-	Secrets         []string `json:"secrets,omitempty"` // Key names from K8s Secrets (not values)
+	Secrets         []string `json:"secrets,omitempty"`      // Key names from K8s Secrets (not values)
+	Instructions    string   `json:"instructions,omitempty"` // User task extracted from spec.instructions
 	CreatedAt       string   `json:"createdAt"`
+}
+
+// extractUserTask extracts the user's task from the full instructions string.
+// The system prompt prefix ends at "## Your Task\n" — everything after that marker is the user task.
+// If no marker is found, the full instructions are returned.
+func extractUserTask(instructions string) string {
+	const marker = "## Your Task\n"
+	idx := strings.Index(instructions, marker)
+	if idx == -1 {
+		return instructions
+	}
+	return strings.TrimSpace(instructions[idx+len(marker):])
 }
 
 type AgentListResponse struct {
@@ -252,6 +266,7 @@ func createOrTriggerAgent(k8s *K8sClient) gin.HandlerFunc {
 					LastTaskCostUSD: existing.Status.LastTaskCostUSD,
 					TotalCostUSD:    existing.Status.TotalCostUSD,
 					Secrets:         collectSecretKeys(*c, k8s, ns, existing.Spec.Secrets),
+					Instructions:    extractUserTask(existing.Spec.Instructions),
 					CreatedAt:       existing.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
 				})
 				return
@@ -297,6 +312,7 @@ func createOrTriggerAgent(k8s *K8sClient) gin.HandlerFunc {
 				LastTaskCostUSD: existing.Status.LastTaskCostUSD,
 				TotalCostUSD:    existing.Status.TotalCostUSD,
 				Secrets:         collectSecretKeys(*c, k8s, ns, existing.Spec.Secrets),
+				Instructions:    extractUserTask(existing.Spec.Instructions),
 				CreatedAt:       existing.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
 			})
 			return
@@ -325,13 +341,14 @@ func createOrTriggerAgent(k8s *K8sClient) gin.HandlerFunc {
 
 		log.Printf("created new agent %s/%s", ns, req.Name)
 		c.JSON(http.StatusCreated, AgentResponse{
-			Name:      agent.Name,
-			Namespace: agent.Namespace,
-			Model:     agent.Spec.Model,
-			Status:    "Pending",
-			Lifecycle: string(agent.Spec.Lifecycle),
-			Secrets:   collectSecretKeys(*c, k8s, ns, agent.Spec.Secrets),
-			CreatedAt: agent.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
+			Name:         agent.Name,
+			Namespace:    agent.Namespace,
+			Model:        agent.Spec.Model,
+			Status:       "Pending",
+			Lifecycle:    string(agent.Spec.Lifecycle),
+			Secrets:      collectSecretKeys(*c, k8s, ns, agent.Spec.Secrets),
+			Instructions: extractUserTask(agent.Spec.Instructions),
+			CreatedAt:    agent.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
 		})
 	}
 }
@@ -451,6 +468,7 @@ func getAgent(k8s *K8sClient) gin.HandlerFunc {
 			LastTaskCostUSD: agent.Status.LastTaskCostUSD,
 			TotalCostUSD:    agent.Status.TotalCostUSD,
 			Secrets:         agent.Spec.Secrets,
+			Instructions:    extractUserTask(agent.Spec.Instructions),
 			CreatedAt:       agent.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
 		})
 	}
@@ -523,6 +541,7 @@ func listAgents(k8s *K8sClient) gin.HandlerFunc {
 				LastTaskCostUSD: a.Status.LastTaskCostUSD,
 				TotalCostUSD:    a.Status.TotalCostUSD,
 				Secrets:         collectSecretKeys(*c, k8s, ns, a.Spec.Secrets),
+				Instructions:    extractUserTask(a.Spec.Instructions),
 				CreatedAt:       a.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
 			})
 		}

--- a/komputer-ui/src/app/agents/[name]/page.tsx
+++ b/komputer-ui/src/app/agents/[name]/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
-import { Ban, Trash2, Zap, KeyRound } from "lucide-react";
+import { Ban, Trash2, Zap, KeyRound, ChevronRight, FileText } from "lucide-react";
 
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/kit/button";
 import { Badge } from "@/components/kit/badge";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/kit/tabs";
@@ -332,6 +333,11 @@ export default function AgentDetailPage() {
               </div>
             </motion.div>
 
+            {/* Instructions */}
+            {agent.instructions && (
+              <InstructionsCard instructions={agent.instructions} />
+            )}
+
             {/* Last message */}
             {agent.lastTaskMessage && (
               <motion.div
@@ -367,6 +373,38 @@ function StatCard({ label, value, color, highlight }: {
         {value}
       </p>
     </div>
+  );
+}
+
+function InstructionsCard({ instructions }: { instructions: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <motion.div
+      className="rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] transition-colors duration-150 hover:border-[var(--color-border-hover)] hover:bg-[var(--color-surface-hover)]"
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: "easeOut", delay: 0.15 }}
+    >
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center gap-2 px-5 py-4 text-left cursor-pointer"
+      >
+        <ChevronRight
+          className={cn(
+            "size-3.5 shrink-0 text-[var(--color-text-secondary)] transition-transform duration-200",
+            open && "rotate-90"
+          )}
+        />
+        <FileText className="size-3.5 text-[var(--color-text-muted)]" />
+        <h3 className="text-[11px] uppercase tracking-wider font-semibold text-[var(--color-text-muted)]">Instructions</h3>
+      </button>
+      {open && (
+        <div className="px-5 pb-4">
+          <p className="text-sm text-[var(--color-text-secondary)] leading-relaxed whitespace-pre-wrap">{instructions}</p>
+        </div>
+      )}
+    </motion.div>
   );
 }
 

--- a/komputer-ui/src/lib/types.ts
+++ b/komputer-ui/src/lib/types.ts
@@ -9,6 +9,7 @@ export interface AgentResponse {
   lastTaskCostUSD?: string;
   totalCostUSD?: string;
   secrets?: string[];
+  instructions?: string;
   createdAt: string;
 }
 


### PR DESCRIPTION
Return instructions in API AgentResponse. Display in a collapsible section in the agent detail Info tab.