### PR TITLE
feat: load older events on scroll up in agent chat

### DIFF
--- a/komputer-api/handler.go
+++ b/komputer-api/handler.go
@@ -483,7 +483,8 @@ func getAgentEvents(worker *RedisWorker) gin.HandlerFunc {
 			}
 			limit = parsed
 		}
-		events, err := GetAgentEvents(c.Request.Context(), worker.Rdb, name, limit, worker.StreamPrefix)
+		before := c.Query("before") // RFC-3339 cursor for pagination
+		events, err := GetAgentEventsBefore(c.Request.Context(), worker.Rdb, name, limit, before, worker.StreamPrefix)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get agent events: " + err.Error()})
 			return

--- a/komputer-api/worker.go
+++ b/komputer-api/worker.go
@@ -433,10 +433,36 @@ func parseStreamMessage(msg redis.XMessage) (AgentEvent, error) {
 // GetAgentEvents reads events from the agent's persistent history list.
 // Returns the last `limit` events in chronological order.
 func GetAgentEvents(ctx context.Context, rdb *redis.Client, agentName string, limit int64, streamPrefix string) ([]AgentEvent, error) {
+	return GetAgentEventsBefore(ctx, rdb, agentName, limit, "", streamPrefix)
+}
+
+// GetAgentEventsBefore returns up to `limit` events for the agent. When `before`
+// is non-empty it must be an RFC-3339 timestamp; only events with a timestamp
+// strictly before that value are returned. Because the backing store is a Redis
+// list (not an indexed DB), we over-fetch and filter in Go — the list is bounded
+// at ~200 entries per task so this is fine.
+func GetAgentEventsBefore(ctx context.Context, rdb *redis.Client, agentName string, limit int64, before string, streamPrefix string) ([]AgentEvent, error) {
 	historyKey := fmt.Sprintf("komputer-history:%s", agentName)
 
+	var beforeTime time.Time
+	hasBefore := before != ""
+	if hasBefore {
+		var err error
+		beforeTime, err = time.Parse(time.RFC3339Nano, before)
+		if err != nil {
+			return nil, fmt.Errorf("invalid before timestamp: %w", err)
+		}
+	}
+
+	// When filtering by `before` we need to fetch more than `limit` items because
+	// some will be filtered out. Fetch the entire list (bounded at ~200).
+	fetchCount := limit
+	if hasBefore {
+		fetchCount = 200
+	}
+
 	// LRANGE with negative indices gets the last N items.
-	vals, err := rdb.LRange(ctx, historyKey, -limit, -1).Result()
+	vals, err := rdb.LRange(ctx, historyKey, -fetchCount, -1).Result()
 	if err != nil {
 		return nil, fmt.Errorf("lrange: %w", err)
 	}
@@ -448,8 +474,24 @@ func GetAgentEvents(ctx context.Context, rdb *redis.Client, agentName string, li
 			log.Printf("skipping malformed history entry: %v", err)
 			continue
 		}
+		if hasBefore {
+			evTime, err := time.Parse(time.RFC3339Nano, ev.Timestamp)
+			if err != nil {
+				continue
+			}
+			if !evTime.Before(beforeTime) {
+				continue
+			}
+		}
 		events = append(events, ev)
 	}
+
+	// When filtering by before, we want the *last* `limit` events that matched
+	// (i.e. the ones closest to the cursor).
+	if hasBefore && int64(len(events)) > limit {
+		events = events[len(events)-int(limit):]
+	}
+
 	return events, nil
 }
 

--- a/komputer-ui/src/app/agents/[name]/page.tsx
+++ b/komputer-ui/src/app/agents/[name]/page.tsx
@@ -34,17 +34,46 @@ export default function AgentDetailPage() {
 
   const { events: wsEvents } = useWebSocket(agentName);
   const [historyEvents, setHistoryEvents] = useState<AgentEvent[]>([]);
+  const [hasMoreEvents, setHasMoreEvents] = useState(true);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+
+  const parseEventsResponse = useCallback((data: unknown): AgentEvent[] => {
+    return Array.isArray(data) ? data : (data as { events?: AgentEvent[] })?.events ?? [];
+  }, []);
 
   // Fetch event history on mount
   useEffect(() => {
     if (!agentName) return;
     getAgentEvents(agentName, 50, agentNs)
       .then((data: unknown) => {
-        const arr = Array.isArray(data) ? data : (data as { events?: AgentEvent[] })?.events ?? [];
+        const arr = parseEventsResponse(data);
         setHistoryEvents(arr);
+        if (arr.length < 50) setHasMoreEvents(false);
       })
       .catch(() => {});
-  }, [agentName, agentNs]);
+  }, [agentName, agentNs, parseEventsResponse]);
+
+  // Load older events (called when user scrolls to top)
+  const loadOlderEvents = useCallback(async () => {
+    if (!agentName || loadingOlder || !hasMoreEvents) return;
+    const oldestTimestamp = historyEvents.length > 0 ? historyEvents[0].timestamp : undefined;
+    if (!oldestTimestamp) return;
+    setLoadingOlder(true);
+    try {
+      const data = await getAgentEvents(agentName, 50, agentNs, oldestTimestamp);
+      const older = parseEventsResponse(data);
+      if (older.length === 0) {
+        setHasMoreEvents(false);
+      } else {
+        setHistoryEvents((prev) => [...older, ...prev]);
+        if (older.length < 50) setHasMoreEvents(false);
+      }
+    } catch {
+      // Silently fail, user can scroll up again to retry
+    } finally {
+      setLoadingOlder(false);
+    }
+  }, [agentName, agentNs, historyEvents, loadingOlder, hasMoreEvents, parseEventsResponse]);
 
   // Merge history + WS events, deduplicating by full fingerprint
   const events = useMemo(() => {
@@ -263,6 +292,9 @@ export default function AgentDetailPage() {
             events={events}
             taskStatus={agent.taskStatus}
             initialPending={agent.taskStatus === "InProgress" ? initialPending : undefined}
+            hasMoreEvents={hasMoreEvents}
+            loadingOlder={loadingOlder}
+            onLoadOlder={loadOlderEvents}
           />
         </TabsContent>
 

--- a/komputer-ui/src/components/agents/agent-chat.tsx
+++ b/komputer-ui/src/components/agents/agent-chat.tsx
@@ -29,6 +29,9 @@ type AgentChatProps = {
   events: AgentEvent[];
   taskStatus?: string;
   initialPending?: string;
+  hasMoreEvents?: boolean;
+  loadingOlder?: boolean;
+  onLoadOlder?: () => void;
 };
 
 // --- Message types derived from events ---
@@ -395,6 +398,9 @@ export function AgentChat({
   events,
   taskStatus,
   initialPending,
+  hasMoreEvents,
+  loadingOlder,
+  onLoadOlder,
 }: AgentChatProps) {
   const [input, setInput] = useState("");
   const [lifecycle, setLifecycle] = useState<"" | "Sleep" | "AutoDelete">("");
@@ -420,8 +426,11 @@ export function AgentChat({
       : []
   );
   const bottomRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const eventCountAtSend = useRef(events.length);
+  const prevMessagesLenRef = useRef(0);
 
   const serverMessages = eventsToChatMessages(events);
 
@@ -473,10 +482,66 @@ export function AgentChat({
     return all.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
   })();
 
-  // Auto-scroll on new messages
+  // Preserve scroll position when older messages are prepended
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const prevLen = prevMessagesLenRef.current;
+    const curLen = messages.length;
+    // If messages were added at the top (prepended), restore scroll position
+    if (prevLen > 0 && curLen > prevLen) {
+      const delta = curLen - prevLen;
+      // Check if scroll was near the top (user was scrolling up to load more)
+      // We use a threshold to avoid interfering with normal bottom-scroll
+      if (container.scrollTop < 200) {
+        // Defer to after DOM paint
+        requestAnimationFrame(() => {
+          // Measure the height of newly prepended items
+          const children = container.querySelector("[data-messages]")?.children;
+          if (children) {
+            let addedHeight = 0;
+            for (let i = 0; i < delta && i < children.length; i++) {
+              addedHeight += (children[i] as HTMLElement).offsetHeight + 12; // 12 = gap-3
+            }
+            container.scrollTop = addedHeight;
+          }
+        });
+      }
+    }
+    prevMessagesLenRef.current = curLen;
   }, [messages.length]);
+
+  // Auto-scroll on new messages (only when user is near the bottom)
+  const prevMsgCountRef = useRef(0);
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const prevCount = prevMsgCountRef.current;
+    prevMsgCountRef.current = messages.length;
+    if (prevCount === 0 || messages.length <= prevCount) return;
+    // Only auto-scroll if user is near the bottom
+    const distFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+    if (distFromBottom < 150) {
+      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [messages.length]);
+
+  // IntersectionObserver to trigger loading older events when sentinel is visible
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const container = scrollContainerRef.current;
+    if (!sentinel || !container || !onLoadOlder) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMoreEvents && !loadingOlder) {
+          onLoadOlder();
+        }
+      },
+      { root: container, threshold: 0.1 }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMoreEvents, loadingOlder, onLoadOlder]);
 
   const handleSend = useCallback(async () => {
     const text = input.trim();
@@ -510,7 +575,7 @@ export function AgentChat({
   return (
     <div className="flex h-full flex-col">
       {/* Messages area */}
-      <div className="flex-1 overflow-y-auto px-4 pt-4 pb-4">
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto px-4 pt-4 pb-4">
         {messages.length === 0 && !showThinking ? (
           <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-secondary)]">
             {agentStatus === "Sleeping"
@@ -518,7 +583,28 @@ export function AgentChat({
               : "No messages yet. Waiting for events..."}
           </div>
         ) : (
-          <div className="flex flex-col gap-3">
+          <div data-messages className="flex flex-col gap-3">
+            {/* Sentinel for infinite scroll */}
+            <div ref={sentinelRef} className="h-1 shrink-0" />
+            {loadingOlder && (
+              <div className="flex justify-center py-2">
+                <div className="flex items-center gap-2">
+                  {[0, 1, 2].map((i) => (
+                    <motion.span
+                      key={i}
+                      className="size-1.5 rounded-full bg-[var(--color-text-secondary)]"
+                      animate={{ opacity: [0.3, 1, 0.3] }}
+                      transition={{
+                        duration: 1,
+                        repeat: Infinity,
+                        delay: i * 0.15,
+                        ease: "easeInOut",
+                      }}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
             <AnimatePresence initial={false}>
             {messages.map((msg, i) => {
               switch (msg.kind) {

--- a/komputer-ui/src/lib/api.ts
+++ b/komputer-ui/src/lib/api.ts
@@ -48,8 +48,8 @@ export const deleteAgent = (name: string, ns?: string) =>
 export const cancelAgent = (name: string, ns?: string) =>
   request<void>(`/agents/${name}/cancel${ns ? `?namespace=${ns}` : ''}`, { method: 'POST' });
 
-export const getAgentEvents = (name: string, limit = 50, ns?: string) =>
-  request<AgentEvent[]>(`/agents/${name}/events?limit=${limit}${ns ? `&namespace=${ns}` : ''}`);
+export const getAgentEvents = (name: string, limit = 50, ns?: string, before?: string) =>
+  request<AgentEvent[]>(`/agents/${name}/events?limit=${limit}${ns ? `&namespace=${ns}` : ''}${before ? `&before=${encodeURIComponent(before)}` : ''}`);
 
 // Offices
 export const listOffices = (ns?: string) =>


### PR DESCRIPTION
## Summary
- Add `before` query parameter to the GET `/agents/{name}/events` endpoint for cursor-based pagination. The backend fetches from the Redis list and filters events with `timestamp < before` in Go.
- Implement infinite scroll in the agent chat UI: an IntersectionObserver on a sentinel element at the top of the messages area triggers loading older events automatically when the user scrolls up.
- Preserve scroll position when older events are prepended, and show a subtle loading spinner at the top during fetch.

## Test plan
- [ ] Verify `GET /agents/{name}/events?limit=10&before=<timestamp>` returns only events older than the given timestamp
- [ ] Verify the existing `limit`-only behavior is unchanged (no `before` param)
- [ ] Open an agent chat with many events, scroll to the top, and confirm older events load automatically
- [ ] Confirm no jarring scroll jumps when older events are prepended
- [ ] Confirm loading spinner appears at top while fetching
- [ ] Confirm fetching stops when no more events are available
- [ ] Run `cd komputer-api && go build ./...` -- passes
- [ ] Run `cd komputer-ui && npm run build` -- passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)