### PR TITLE
docs(api): add swagger annotations for all endpoints

### DIFF
--- a/komputer-api/docs/docs.go
+++ b/komputer-api/docs/docs.go
@@ -222,6 +222,69 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "patch": {
+                "description": "Updates model, lifecycle, instructions, secretRefs, memories, skills, or connectors on an existing agent.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Patch agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.PatchAgentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated agent",
+                        "schema": {
+                            "$ref": "#/definitions/main.AgentResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/agents/{name}/cancel": {
@@ -368,6 +431,1498 @@ const docTemplate = `{
                 ],
                 "responses": {}
             }
+        },
+        "/connectors": {
+            "get": {
+                "description": "Returns all connectors with attached agent counts in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "List connectors",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of connectors",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new KomputerConnector CR pointing to an MCP server that can be attached to agents.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Create connector",
+                "parameters": [
+                    {
+                        "description": "Connector creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.CreateConnectorRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Connector created",
+                        "schema": {
+                            "$ref": "#/definitions/main.ConnectorResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/connectors/{name}": {
+            "get": {
+                "description": "Returns the URL, service, type, and auth config for a single connector.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Get connector details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Connector details",
+                        "schema": {
+                            "$ref": "#/definitions/main.ConnectorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Connector not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the connector CR.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Delete connector",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Connector deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/connectors/{name}/tools": {
+            "get": {
+                "description": "Calls the MCP server's tools/list endpoint and returns the available tools.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "List connector tools",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of MCP tools",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Connector not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Failed to reach MCP server",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/memories": {
+            "get": {
+                "description": "Returns all memories with content and attached agent counts in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "List memories",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of memories",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new KomputerMemory CR that can be attached to agents as persistent context.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Create memory",
+                "parameters": [
+                    {
+                        "description": "Memory creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.CreateMemoryRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Memory created",
+                        "schema": {
+                            "$ref": "#/definitions/main.MemoryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/memories/{name}": {
+            "get": {
+                "description": "Returns the content and attached agent count for a single memory.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Get memory details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Memory name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Memory details",
+                        "schema": {
+                            "$ref": "#/definitions/main.MemoryResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Memory not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the memory CR.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Delete memory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Memory name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Memory deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Updates the content or description of an existing memory.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Patch memory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Memory name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.PatchMemoryRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated memory",
+                        "schema": {
+                            "$ref": "#/definitions/main.MemoryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/namespaces": {
+            "get": {
+                "description": "Returns all Kubernetes namespaces the API has access to.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "List namespaces",
+                "responses": {
+                    "200": {
+                        "description": "List of namespaces",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/offices": {
+            "get": {
+                "description": "Returns all offices with their current status in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "offices"
+                ],
+                "summary": "List offices",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of offices",
+                        "schema": {
+                            "$ref": "#/definitions/main.OfficeListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/offices/{name}": {
+            "get": {
+                "description": "Returns the current status and member list for a single office.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "offices"
+                ],
+                "summary": "Get office details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Office name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Office details",
+                        "schema": {
+                            "$ref": "#/definitions/main.OfficeResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Office not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the office CR and cleans up Redis event streams for all member agents.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "offices"
+                ],
+                "summary": "Delete office",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Office name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Office deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Office not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/offices/{name}/events": {
+            "get": {
+                "description": "Returns merged events from all member agent Redis streams, sorted chronologically.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "offices"
+                ],
+                "summary": "Get office events",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Office name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Max events to return (1-200)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Office events",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid limit parameter",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Office not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/schedules": {
+            "get": {
+                "description": "Returns all schedules with their current status and run history in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "List schedules",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of schedules",
+                        "schema": {
+                            "$ref": "#/definitions/main.ScheduleListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new KomputerSchedule CR that triggers agent tasks on a cron schedule.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "Create schedule",
+                "parameters": [
+                    {
+                        "description": "Schedule creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.CreateScheduleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Schedule created",
+                        "schema": {
+                            "$ref": "#/definitions/main.ScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/schedules/{name}": {
+            "get": {
+                "description": "Returns the current status and run history for a single schedule.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "Get schedule details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Schedule name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Schedule details",
+                        "schema": {
+                            "$ref": "#/definitions/main.ScheduleResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Schedule not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the schedule CR. Does not delete any agents that were created by the schedule.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "Delete schedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Schedule name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Schedule deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Schedule not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Updates the cron expression for an existing schedule.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "Patch schedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Schedule name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.PatchScheduleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated schedule",
+                        "schema": {
+                            "$ref": "#/definitions/main.ScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/secrets": {
+            "get": {
+                "description": "Returns all secrets with key names (not values) and attached agent counts in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "secrets"
+                ],
+                "summary": "List secrets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include all secrets, not just managed ones",
+                        "name": "all",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of secrets",
+                        "schema": {
+                            "$ref": "#/definitions/main.SecretListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new Kubernetes secret managed by komputer.ai that can be attached to agents.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "secrets"
+                ],
+                "summary": "Create managed secret",
+                "parameters": [
+                    {
+                        "description": "Secret creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.CreateSecretRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Secret created",
+                        "schema": {
+                            "$ref": "#/definitions/main.SecretResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/secrets/{name}": {
+            "delete": {
+                "description": "Deletes a managed Kubernetes secret.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "secrets"
+                ],
+                "summary": "Delete managed secret",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Secret name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Secret deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Replaces the key-value pairs in a managed Kubernetes secret.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "secrets"
+                ],
+                "summary": "Update managed secret",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Secret name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Updated secret data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.UpdateSecretRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Secret updated",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/skills": {
+            "get": {
+                "description": "Returns all skills with content and attached agent counts in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "List skills",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of skills",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new KomputerSkill CR with script content that can be attached to agents.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Create skill",
+                "parameters": [
+                    {
+                        "description": "Skill creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.CreateSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Skill created",
+                        "schema": {
+                            "$ref": "#/definitions/main.SkillResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/skills/{name}": {
+            "get": {
+                "description": "Returns the content, description, and attached agent count for a single skill.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Get skill details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Skill name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Skill details",
+                        "schema": {
+                            "$ref": "#/definitions/main.SkillResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Skill not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the skill CR.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Delete skill",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Skill name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Skill deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Updates the description or script content of an existing skill.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Patch skill",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Skill name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.PatchSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated skill",
+                        "schema": {
+                            "$ref": "#/definitions/main.SkillResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/templates": {
+            "get": {
+                "description": "Returns all agent templates (both namespace-scoped and cluster-scoped) available in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "List agent templates",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of templates",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -385,13 +1940,98 @@ const docTemplate = `{
         "main.AgentResponse": {
             "type": "object",
             "properties": {
+                "connectors": {
+                    "description": "KomputerConnector names attached to this agent",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "createdAt": {
+                    "type": "string"
+                },
+                "instructions": {
+                    "description": "User task extracted from spec.instructions",
+                    "type": "string"
+                },
+                "lastTaskCostUSD": {
                     "type": "string"
                 },
                 "lastTaskMessage": {
                     "type": "string"
                 },
+                "lifecycle": {
+                    "type": "string"
+                },
+                "memories": {
+                    "description": "KomputerMemory names attached to this agent",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "model": {
+                    "type": "string"
+                },
+                "modelContextWindow": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "secrets": {
+                    "description": "Key names from K8s Secrets (not values)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "skills": {
+                    "description": "KomputerSkill names attached to this agent",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "taskStatus": {
+                    "type": "string"
+                },
+                "totalCostUSD": {
+                    "type": "string"
+                },
+                "totalTokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "main.ConnectorResponse": {
+            "type": "object",
+            "properties": {
+                "agentNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attachedAgents": {
+                    "type": "integer"
+                },
+                "authSecretKey": {
+                    "type": "string"
+                },
+                "authSecretName": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "displayName": {
                     "type": "string"
                 },
                 "name": {
@@ -400,10 +2040,13 @@ const docTemplate = `{
                 "namespace": {
                     "type": "string"
                 },
-                "status": {
+                "service": {
                     "type": "string"
                 },
-                "taskStatus": {
+                "type": {
+                    "type": "string"
+                },
+                "url": {
                     "type": "string"
                 }
             }
@@ -415,8 +2058,26 @@ const docTemplate = `{
                 "name"
             ],
             "properties": {
+                "connectors": {
+                    "description": "optional KomputerConnector names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "instructions": {
                     "type": "string"
+                },
+                "lifecycle": {
+                    "description": "\"\", \"Sleep\", or \"AutoDelete\"",
+                    "type": "string"
+                },
+                "memories": {
+                    "description": "optional KomputerMemory names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "model": {
                     "type": "string"
@@ -428,18 +2089,528 @@ const docTemplate = `{
                     "description": "optional, defaults to server default",
                     "type": "string"
                 },
+                "officeManager": {
+                    "description": "set by manager MCP tool",
+                    "type": "string"
+                },
                 "role": {
                     "description": "\"manager\" or \"\" (default manager)",
                     "type": "string"
                 },
-                "secrets": {
-                    "description": "optional key-value secrets (e.g. {\"GITHUB\": \"ghp_xxx\"})",
+                "secretRefs": {
+                    "description": "names of existing K8s Secrets to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "skills": {
+                    "description": "optional KomputerSkill names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "templateRef": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateConnectorRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "service",
+                "url"
+            ],
+            "properties": {
+                "authSecretKey": {
+                    "type": "string"
+                },
+                "authSecretName": {
+                    "type": "string"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "service": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateMemoryRequest": {
+            "type": "object",
+            "required": [
+                "content",
+                "name"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateScheduleAgentSpec": {
+            "type": "object",
+            "properties": {
+                "lifecycle": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "secretRefs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "templateRef": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateScheduleRequest": {
+            "type": "object",
+            "required": [
+                "instructions",
+                "name",
+                "schedule"
+            ],
+            "properties": {
+                "agent": {
+                    "$ref": "#/definitions/main.CreateScheduleAgentSpec"
+                },
+                "agentName": {
+                    "type": "string"
+                },
+                "autoDelete": {
+                    "type": "boolean"
+                },
+                "instructions": {
+                    "type": "string"
+                },
+                "keepAgents": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "timezone": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateSecretRequest": {
+            "type": "object",
+            "required": [
+                "data",
+                "name"
+            ],
+            "properties": {
+                "data": {
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateSkillRequest": {
+            "type": "object",
+            "required": [
+                "content",
+                "description",
+                "name"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.MemoryResponse": {
+            "type": "object",
+            "properties": {
+                "agentNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attachedAgents": {
+                    "type": "integer"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.OfficeListResponse": {
+            "type": "object",
+            "properties": {
+                "offices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.OfficeResponse"
+                    }
+                }
+            }
+        },
+        "main.OfficeMemberResponse": {
+            "type": "object",
+            "properties": {
+                "lastTaskCostUSD": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "taskStatus": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.OfficeResponse": {
+            "type": "object",
+            "properties": {
+                "activeAgents": {
+                    "type": "integer"
+                },
+                "completedAgents": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "manager": {
+                    "type": "string"
+                },
+                "members": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.OfficeMemberResponse"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "phase": {
+                    "type": "string"
+                },
+                "totalAgents": {
+                    "type": "integer"
+                },
+                "totalCostUSD": {
+                    "type": "string"
+                },
+                "totalTokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "main.PatchAgentRequest": {
+            "type": "object",
+            "properties": {
+                "connectors": {
+                    "description": "connector names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "instructions": {
+                    "type": "string"
+                },
+                "lifecycle": {
+                    "type": "string"
+                },
+                "memories": {
+                    "description": "memory names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "model": {
+                    "type": "string"
+                },
+                "secretRefs": {
+                    "description": "full replacement list of K8s secret names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "skills": {
+                    "description": "skill names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "templateRef": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.PatchMemoryRequest": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.PatchScheduleRequest": {
+            "type": "object",
+            "properties": {
+                "schedule": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.PatchSkillRequest": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.ScheduleListResponse": {
+            "type": "object",
+            "properties": {
+                "schedules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.ScheduleResponse"
+                    }
+                }
+            }
+        },
+        "main.ScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "agentName": {
+                    "type": "string"
+                },
+                "autoDelete": {
+                    "type": "boolean"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "failedRuns": {
+                    "type": "integer"
+                },
+                "keepAgents": {
+                    "type": "boolean"
+                },
+                "lastRunCostUSD": {
+                    "type": "string"
+                },
+                "lastRunStatus": {
+                    "type": "string"
+                },
+                "lastRunTime": {
+                    "type": "string"
+                },
+                "lastRunTokens": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "nextRunTime": {
+                    "type": "string"
+                },
+                "phase": {
+                    "type": "string"
+                },
+                "runCount": {
+                    "type": "integer"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "successfulRuns": {
+                    "type": "integer"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "totalCostUSD": {
+                    "type": "string"
+                },
+                "totalTokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "main.SecretListResponse": {
+            "type": "object",
+            "properties": {
+                "secrets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.SecretResponse"
+                    }
+                }
+            }
+        },
+        "main.SecretResponse": {
+            "type": "object",
+            "properties": {
+                "agentName": {
+                    "type": "string"
+                },
+                "agentNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attachedAgents": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "managed": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.SkillResponse": {
+            "type": "object",
+            "properties": {
+                "agentNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attachedAgents": {
+                    "type": "integer"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "isDefault": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.UpdateSecretRequest": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
                     "type": "string"
                 }
             }

--- a/komputer-api/docs/swagger.json
+++ b/komputer-api/docs/swagger.json
@@ -216,6 +216,69 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "description": "Updates model, lifecycle, instructions, secretRefs, memories, skills, or connectors on an existing agent.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Patch agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.PatchAgentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated agent",
+                        "schema": {
+                            "$ref": "#/definitions/main.AgentResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/agents/{name}/cancel": {
@@ -362,6 +425,1498 @@
                 ],
                 "responses": {}
             }
+        },
+        "/connectors": {
+            "get": {
+                "description": "Returns all connectors with attached agent counts in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "List connectors",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of connectors",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new KomputerConnector CR pointing to an MCP server that can be attached to agents.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Create connector",
+                "parameters": [
+                    {
+                        "description": "Connector creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.CreateConnectorRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Connector created",
+                        "schema": {
+                            "$ref": "#/definitions/main.ConnectorResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/connectors/{name}": {
+            "get": {
+                "description": "Returns the URL, service, type, and auth config for a single connector.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Get connector details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Connector details",
+                        "schema": {
+                            "$ref": "#/definitions/main.ConnectorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Connector not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the connector CR.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Delete connector",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Connector deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/connectors/{name}/tools": {
+            "get": {
+                "description": "Calls the MCP server's tools/list endpoint and returns the available tools.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "List connector tools",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of MCP tools",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Connector not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Failed to reach MCP server",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/memories": {
+            "get": {
+                "description": "Returns all memories with content and attached agent counts in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "List memories",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of memories",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new KomputerMemory CR that can be attached to agents as persistent context.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Create memory",
+                "parameters": [
+                    {
+                        "description": "Memory creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.CreateMemoryRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Memory created",
+                        "schema": {
+                            "$ref": "#/definitions/main.MemoryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/memories/{name}": {
+            "get": {
+                "description": "Returns the content and attached agent count for a single memory.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Get memory details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Memory name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Memory details",
+                        "schema": {
+                            "$ref": "#/definitions/main.MemoryResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Memory not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the memory CR.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Delete memory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Memory name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Memory deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Updates the content or description of an existing memory.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Patch memory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Memory name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.PatchMemoryRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated memory",
+                        "schema": {
+                            "$ref": "#/definitions/main.MemoryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/namespaces": {
+            "get": {
+                "description": "Returns all Kubernetes namespaces the API has access to.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "List namespaces",
+                "responses": {
+                    "200": {
+                        "description": "List of namespaces",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/offices": {
+            "get": {
+                "description": "Returns all offices with their current status in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "offices"
+                ],
+                "summary": "List offices",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of offices",
+                        "schema": {
+                            "$ref": "#/definitions/main.OfficeListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/offices/{name}": {
+            "get": {
+                "description": "Returns the current status and member list for a single office.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "offices"
+                ],
+                "summary": "Get office details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Office name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Office details",
+                        "schema": {
+                            "$ref": "#/definitions/main.OfficeResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Office not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the office CR and cleans up Redis event streams for all member agents.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "offices"
+                ],
+                "summary": "Delete office",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Office name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Office deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Office not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/offices/{name}/events": {
+            "get": {
+                "description": "Returns merged events from all member agent Redis streams, sorted chronologically.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "offices"
+                ],
+                "summary": "Get office events",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Office name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Max events to return (1-200)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Office events",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid limit parameter",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Office not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/schedules": {
+            "get": {
+                "description": "Returns all schedules with their current status and run history in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "List schedules",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of schedules",
+                        "schema": {
+                            "$ref": "#/definitions/main.ScheduleListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new KomputerSchedule CR that triggers agent tasks on a cron schedule.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "Create schedule",
+                "parameters": [
+                    {
+                        "description": "Schedule creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.CreateScheduleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Schedule created",
+                        "schema": {
+                            "$ref": "#/definitions/main.ScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/schedules/{name}": {
+            "get": {
+                "description": "Returns the current status and run history for a single schedule.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "Get schedule details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Schedule name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Schedule details",
+                        "schema": {
+                            "$ref": "#/definitions/main.ScheduleResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Schedule not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the schedule CR. Does not delete any agents that were created by the schedule.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "Delete schedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Schedule name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Schedule deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Schedule not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Updates the cron expression for an existing schedule.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "Patch schedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Schedule name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.PatchScheduleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated schedule",
+                        "schema": {
+                            "$ref": "#/definitions/main.ScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/secrets": {
+            "get": {
+                "description": "Returns all secrets with key names (not values) and attached agent counts in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "secrets"
+                ],
+                "summary": "List secrets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include all secrets, not just managed ones",
+                        "name": "all",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of secrets",
+                        "schema": {
+                            "$ref": "#/definitions/main.SecretListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new Kubernetes secret managed by komputer.ai that can be attached to agents.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "secrets"
+                ],
+                "summary": "Create managed secret",
+                "parameters": [
+                    {
+                        "description": "Secret creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.CreateSecretRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Secret created",
+                        "schema": {
+                            "$ref": "#/definitions/main.SecretResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/secrets/{name}": {
+            "delete": {
+                "description": "Deletes a managed Kubernetes secret.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "secrets"
+                ],
+                "summary": "Delete managed secret",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Secret name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Secret deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Replaces the key-value pairs in a managed Kubernetes secret.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "secrets"
+                ],
+                "summary": "Update managed secret",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Secret name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Updated secret data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.UpdateSecretRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Secret updated",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/skills": {
+            "get": {
+                "description": "Returns all skills with content and attached agent counts in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "List skills",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of skills",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new KomputerSkill CR with script content that can be attached to agents.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Create skill",
+                "parameters": [
+                    {
+                        "description": "Skill creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.CreateSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Skill created",
+                        "schema": {
+                            "$ref": "#/definitions/main.SkillResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/skills/{name}": {
+            "get": {
+                "description": "Returns the content, description, and attached agent count for a single skill.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Get skill details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Skill name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Skill details",
+                        "schema": {
+                            "$ref": "#/definitions/main.SkillResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Skill not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the skill CR.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Delete skill",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Skill name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Skill deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Updates the description or script content of an existing skill.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Patch skill",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Skill name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.PatchSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated skill",
+                        "schema": {
+                            "$ref": "#/definitions/main.SkillResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/templates": {
+            "get": {
+                "description": "Returns all agent templates (both namespace-scoped and cluster-scoped) available in the specified namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "List agent templates",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of templates",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -379,13 +1934,98 @@
         "main.AgentResponse": {
             "type": "object",
             "properties": {
+                "connectors": {
+                    "description": "KomputerConnector names attached to this agent",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "createdAt": {
+                    "type": "string"
+                },
+                "instructions": {
+                    "description": "User task extracted from spec.instructions",
+                    "type": "string"
+                },
+                "lastTaskCostUSD": {
                     "type": "string"
                 },
                 "lastTaskMessage": {
                     "type": "string"
                 },
+                "lifecycle": {
+                    "type": "string"
+                },
+                "memories": {
+                    "description": "KomputerMemory names attached to this agent",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "model": {
+                    "type": "string"
+                },
+                "modelContextWindow": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "secrets": {
+                    "description": "Key names from K8s Secrets (not values)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "skills": {
+                    "description": "KomputerSkill names attached to this agent",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "taskStatus": {
+                    "type": "string"
+                },
+                "totalCostUSD": {
+                    "type": "string"
+                },
+                "totalTokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "main.ConnectorResponse": {
+            "type": "object",
+            "properties": {
+                "agentNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attachedAgents": {
+                    "type": "integer"
+                },
+                "authSecretKey": {
+                    "type": "string"
+                },
+                "authSecretName": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "displayName": {
                     "type": "string"
                 },
                 "name": {
@@ -394,10 +2034,13 @@
                 "namespace": {
                     "type": "string"
                 },
-                "status": {
+                "service": {
                     "type": "string"
                 },
-                "taskStatus": {
+                "type": {
+                    "type": "string"
+                },
+                "url": {
                     "type": "string"
                 }
             }
@@ -409,8 +2052,26 @@
                 "name"
             ],
             "properties": {
+                "connectors": {
+                    "description": "optional KomputerConnector names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "instructions": {
                     "type": "string"
+                },
+                "lifecycle": {
+                    "description": "\"\", \"Sleep\", or \"AutoDelete\"",
+                    "type": "string"
+                },
+                "memories": {
+                    "description": "optional KomputerMemory names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "model": {
                     "type": "string"
@@ -422,18 +2083,528 @@
                     "description": "optional, defaults to server default",
                     "type": "string"
                 },
+                "officeManager": {
+                    "description": "set by manager MCP tool",
+                    "type": "string"
+                },
                 "role": {
                     "description": "\"manager\" or \"\" (default manager)",
                     "type": "string"
                 },
-                "secrets": {
-                    "description": "optional key-value secrets (e.g. {\"GITHUB\": \"ghp_xxx\"})",
+                "secretRefs": {
+                    "description": "names of existing K8s Secrets to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "skills": {
+                    "description": "optional KomputerSkill names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "templateRef": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateConnectorRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "service",
+                "url"
+            ],
+            "properties": {
+                "authSecretKey": {
+                    "type": "string"
+                },
+                "authSecretName": {
+                    "type": "string"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "service": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateMemoryRequest": {
+            "type": "object",
+            "required": [
+                "content",
+                "name"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateScheduleAgentSpec": {
+            "type": "object",
+            "properties": {
+                "lifecycle": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "secretRefs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "templateRef": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateScheduleRequest": {
+            "type": "object",
+            "required": [
+                "instructions",
+                "name",
+                "schedule"
+            ],
+            "properties": {
+                "agent": {
+                    "$ref": "#/definitions/main.CreateScheduleAgentSpec"
+                },
+                "agentName": {
+                    "type": "string"
+                },
+                "autoDelete": {
+                    "type": "boolean"
+                },
+                "instructions": {
+                    "type": "string"
+                },
+                "keepAgents": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "timezone": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateSecretRequest": {
+            "type": "object",
+            "required": [
+                "data",
+                "name"
+            ],
+            "properties": {
+                "data": {
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.CreateSkillRequest": {
+            "type": "object",
+            "required": [
+                "content",
+                "description",
+                "name"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.MemoryResponse": {
+            "type": "object",
+            "properties": {
+                "agentNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attachedAgents": {
+                    "type": "integer"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.OfficeListResponse": {
+            "type": "object",
+            "properties": {
+                "offices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.OfficeResponse"
+                    }
+                }
+            }
+        },
+        "main.OfficeMemberResponse": {
+            "type": "object",
+            "properties": {
+                "lastTaskCostUSD": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "taskStatus": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.OfficeResponse": {
+            "type": "object",
+            "properties": {
+                "activeAgents": {
+                    "type": "integer"
+                },
+                "completedAgents": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "manager": {
+                    "type": "string"
+                },
+                "members": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.OfficeMemberResponse"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "phase": {
+                    "type": "string"
+                },
+                "totalAgents": {
+                    "type": "integer"
+                },
+                "totalCostUSD": {
+                    "type": "string"
+                },
+                "totalTokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "main.PatchAgentRequest": {
+            "type": "object",
+            "properties": {
+                "connectors": {
+                    "description": "connector names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "instructions": {
+                    "type": "string"
+                },
+                "lifecycle": {
+                    "type": "string"
+                },
+                "memories": {
+                    "description": "memory names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "model": {
+                    "type": "string"
+                },
+                "secretRefs": {
+                    "description": "full replacement list of K8s secret names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "skills": {
+                    "description": "skill names to attach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "templateRef": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.PatchMemoryRequest": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.PatchScheduleRequest": {
+            "type": "object",
+            "properties": {
+                "schedule": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.PatchSkillRequest": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.ScheduleListResponse": {
+            "type": "object",
+            "properties": {
+                "schedules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.ScheduleResponse"
+                    }
+                }
+            }
+        },
+        "main.ScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "agentName": {
+                    "type": "string"
+                },
+                "autoDelete": {
+                    "type": "boolean"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "failedRuns": {
+                    "type": "integer"
+                },
+                "keepAgents": {
+                    "type": "boolean"
+                },
+                "lastRunCostUSD": {
+                    "type": "string"
+                },
+                "lastRunStatus": {
+                    "type": "string"
+                },
+                "lastRunTime": {
+                    "type": "string"
+                },
+                "lastRunTokens": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "nextRunTime": {
+                    "type": "string"
+                },
+                "phase": {
+                    "type": "string"
+                },
+                "runCount": {
+                    "type": "integer"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "successfulRuns": {
+                    "type": "integer"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "totalCostUSD": {
+                    "type": "string"
+                },
+                "totalTokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "main.SecretListResponse": {
+            "type": "object",
+            "properties": {
+                "secrets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.SecretResponse"
+                    }
+                }
+            }
+        },
+        "main.SecretResponse": {
+            "type": "object",
+            "properties": {
+                "agentName": {
+                    "type": "string"
+                },
+                "agentNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attachedAgents": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "managed": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.SkillResponse": {
+            "type": "object",
+            "properties": {
+                "agentNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attachedAgents": {
+                    "type": "integer"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "isDefault": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.UpdateSecretRequest": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
                     "type": "string"
                 }
             }

--- a/komputer-api/docs/swagger.yaml
+++ b/komputer-api/docs/swagger.yaml
@@ -9,25 +9,98 @@ definitions:
     type: object
   main.AgentResponse:
     properties:
+      connectors:
+        description: KomputerConnector names attached to this agent
+        items:
+          type: string
+        type: array
       createdAt:
+        type: string
+      instructions:
+        description: User task extracted from spec.instructions
+        type: string
+      lastTaskCostUSD:
         type: string
       lastTaskMessage:
         type: string
+      lifecycle:
+        type: string
+      memories:
+        description: KomputerMemory names attached to this agent
+        items:
+          type: string
+        type: array
       model:
+        type: string
+      modelContextWindow:
+        type: integer
+      name:
+        type: string
+      namespace:
+        type: string
+      secrets:
+        description: Key names from K8s Secrets (not values)
+        items:
+          type: string
+        type: array
+      skills:
+        description: KomputerSkill names attached to this agent
+        items:
+          type: string
+        type: array
+      status:
+        type: string
+      taskStatus:
+        type: string
+      totalCostUSD:
+        type: string
+      totalTokens:
+        type: integer
+    type: object
+  main.ConnectorResponse:
+    properties:
+      agentNames:
+        items:
+          type: string
+        type: array
+      attachedAgents:
+        type: integer
+      authSecretKey:
+        type: string
+      authSecretName:
+        type: string
+      createdAt:
+        type: string
+      displayName:
         type: string
       name:
         type: string
       namespace:
         type: string
-      status:
+      service:
         type: string
-      taskStatus:
+      type:
+        type: string
+      url:
         type: string
     type: object
   main.CreateAgentRequest:
     properties:
+      connectors:
+        description: optional KomputerConnector names to attach
+        items:
+          type: string
+        type: array
       instructions:
         type: string
+      lifecycle:
+        description: '"", "Sleep", or "AutoDelete"'
+        type: string
+      memories:
+        description: optional KomputerMemory names to attach
+        items:
+          type: string
+        type: array
       model:
         type: string
       name:
@@ -35,19 +108,357 @@ definitions:
       namespace:
         description: optional, defaults to server default
         type: string
+      officeManager:
+        description: set by manager MCP tool
+        type: string
       role:
         description: '"manager" or "" (default manager)'
         type: string
-      secrets:
-        additionalProperties:
+      secretRefs:
+        description: names of existing K8s Secrets to attach
+        items:
           type: string
-        description: 'optional key-value secrets (e.g. {"GITHUB": "ghp_xxx"})'
-        type: object
+        type: array
+      skills:
+        description: optional KomputerSkill names to attach
+        items:
+          type: string
+        type: array
       templateRef:
         type: string
     required:
     - instructions
     - name
+    type: object
+  main.CreateConnectorRequest:
+    properties:
+      authSecretKey:
+        type: string
+      authSecretName:
+        type: string
+      displayName:
+        type: string
+      name:
+        type: string
+      namespace:
+        type: string
+      service:
+        type: string
+      type:
+        type: string
+      url:
+        type: string
+    required:
+    - name
+    - service
+    - url
+    type: object
+  main.CreateMemoryRequest:
+    properties:
+      content:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+      namespace:
+        type: string
+    required:
+    - content
+    - name
+    type: object
+  main.CreateScheduleAgentSpec:
+    properties:
+      lifecycle:
+        type: string
+      model:
+        type: string
+      role:
+        type: string
+      secretRefs:
+        items:
+          type: string
+        type: array
+      templateRef:
+        type: string
+    type: object
+  main.CreateScheduleRequest:
+    properties:
+      agent:
+        $ref: '#/definitions/main.CreateScheduleAgentSpec'
+      agentName:
+        type: string
+      autoDelete:
+        type: boolean
+      instructions:
+        type: string
+      keepAgents:
+        type: boolean
+      name:
+        type: string
+      namespace:
+        type: string
+      schedule:
+        type: string
+      timezone:
+        type: string
+    required:
+    - instructions
+    - name
+    - schedule
+    type: object
+  main.CreateSecretRequest:
+    properties:
+      data:
+        additionalProperties:
+          type: string
+        type: object
+      name:
+        type: string
+      namespace:
+        type: string
+    required:
+    - data
+    - name
+    type: object
+  main.CreateSkillRequest:
+    properties:
+      content:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+      namespace:
+        type: string
+    required:
+    - content
+    - description
+    - name
+    type: object
+  main.MemoryResponse:
+    properties:
+      agentNames:
+        items:
+          type: string
+        type: array
+      attachedAgents:
+        type: integer
+      content:
+        type: string
+      createdAt:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+      namespace:
+        type: string
+    type: object
+  main.OfficeListResponse:
+    properties:
+      offices:
+        items:
+          $ref: '#/definitions/main.OfficeResponse'
+        type: array
+    type: object
+  main.OfficeMemberResponse:
+    properties:
+      lastTaskCostUSD:
+        type: string
+      name:
+        type: string
+      role:
+        type: string
+      taskStatus:
+        type: string
+    type: object
+  main.OfficeResponse:
+    properties:
+      activeAgents:
+        type: integer
+      completedAgents:
+        type: integer
+      createdAt:
+        type: string
+      manager:
+        type: string
+      members:
+        items:
+          $ref: '#/definitions/main.OfficeMemberResponse'
+        type: array
+      name:
+        type: string
+      namespace:
+        type: string
+      phase:
+        type: string
+      totalAgents:
+        type: integer
+      totalCostUSD:
+        type: string
+      totalTokens:
+        type: integer
+    type: object
+  main.PatchAgentRequest:
+    properties:
+      connectors:
+        description: connector names to attach
+        items:
+          type: string
+        type: array
+      instructions:
+        type: string
+      lifecycle:
+        type: string
+      memories:
+        description: memory names to attach
+        items:
+          type: string
+        type: array
+      model:
+        type: string
+      secretRefs:
+        description: full replacement list of K8s secret names
+        items:
+          type: string
+        type: array
+      skills:
+        description: skill names to attach
+        items:
+          type: string
+        type: array
+      templateRef:
+        type: string
+    type: object
+  main.PatchMemoryRequest:
+    properties:
+      content:
+        type: string
+      description:
+        type: string
+    type: object
+  main.PatchScheduleRequest:
+    properties:
+      schedule:
+        type: string
+    type: object
+  main.PatchSkillRequest:
+    properties:
+      content:
+        type: string
+      description:
+        type: string
+    type: object
+  main.ScheduleListResponse:
+    properties:
+      schedules:
+        items:
+          $ref: '#/definitions/main.ScheduleResponse'
+        type: array
+    type: object
+  main.ScheduleResponse:
+    properties:
+      agentName:
+        type: string
+      autoDelete:
+        type: boolean
+      createdAt:
+        type: string
+      failedRuns:
+        type: integer
+      keepAgents:
+        type: boolean
+      lastRunCostUSD:
+        type: string
+      lastRunStatus:
+        type: string
+      lastRunTime:
+        type: string
+      lastRunTokens:
+        type: integer
+      name:
+        type: string
+      namespace:
+        type: string
+      nextRunTime:
+        type: string
+      phase:
+        type: string
+      runCount:
+        type: integer
+      schedule:
+        type: string
+      successfulRuns:
+        type: integer
+      timezone:
+        type: string
+      totalCostUSD:
+        type: string
+      totalTokens:
+        type: integer
+    type: object
+  main.SecretListResponse:
+    properties:
+      secrets:
+        items:
+          $ref: '#/definitions/main.SecretResponse'
+        type: array
+    type: object
+  main.SecretResponse:
+    properties:
+      agentName:
+        type: string
+      agentNames:
+        items:
+          type: string
+        type: array
+      attachedAgents:
+        type: integer
+      createdAt:
+        type: string
+      keys:
+        items:
+          type: string
+        type: array
+      managed:
+        type: boolean
+      name:
+        type: string
+      namespace:
+        type: string
+    type: object
+  main.SkillResponse:
+    properties:
+      agentNames:
+        items:
+          type: string
+        type: array
+      attachedAgents:
+        type: integer
+      content:
+        type: string
+      createdAt:
+        type: string
+      description:
+        type: string
+      isDefault:
+        type: boolean
+      name:
+        type: string
+      namespace:
+        type: string
+    type: object
+  main.UpdateSecretRequest:
+    properties:
+      data:
+        additionalProperties:
+          type: string
+        type: object
+      namespace:
+        type: string
+    required:
+    - data
     type: object
 host: localhost:8080
 info:
@@ -198,6 +609,49 @@ paths:
       summary: Get agent details
       tags:
       - agents
+    patch:
+      consumes:
+      - application/json
+      description: Updates model, lifecycle, instructions, secretRefs, memories, skills,
+        or connectors on an existing agent.
+      parameters:
+      - description: Agent name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      - description: Fields to update
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/main.PatchAgentRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Updated agent
+          schema:
+            $ref: '#/definitions/main.AgentResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Patch agent
+      tags:
+      - agents
   /agents/{name}/cancel:
     post:
       description: Gracefully cancels the currently running task. The agent pod stays
@@ -299,4 +753,1009 @@ paths:
       summary: Stream agent events (WebSocket)
       tags:
       - agents
+  /connectors:
+    get:
+      description: Returns all connectors with attached agent counts in the specified
+        namespace.
+      parameters:
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of connectors
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List connectors
+      tags:
+      - connectors
+    post:
+      consumes:
+      - application/json
+      description: Creates a new KomputerConnector CR pointing to an MCP server that
+        can be attached to agents.
+      parameters:
+      - description: Connector creation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/main.CreateConnectorRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Connector created
+          schema:
+            $ref: '#/definitions/main.ConnectorResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create connector
+      tags:
+      - connectors
+  /connectors/{name}:
+    delete:
+      description: Deletes the connector CR.
+      parameters:
+      - description: Connector name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Connector deleted
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete connector
+      tags:
+      - connectors
+    get:
+      description: Returns the URL, service, type, and auth config for a single connector.
+      parameters:
+      - description: Connector name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Connector details
+          schema:
+            $ref: '#/definitions/main.ConnectorResponse'
+        "404":
+          description: Connector not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get connector details
+      tags:
+      - connectors
+  /connectors/{name}/tools:
+    get:
+      description: Calls the MCP server's tools/list endpoint and returns the available
+        tools.
+      parameters:
+      - description: Connector name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of MCP tools
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Connector not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "502":
+          description: Failed to reach MCP server
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List connector tools
+      tags:
+      - connectors
+  /memories:
+    get:
+      description: Returns all memories with content and attached agent counts in
+        the specified namespace.
+      parameters:
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of memories
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List memories
+      tags:
+      - memories
+    post:
+      consumes:
+      - application/json
+      description: Creates a new KomputerMemory CR that can be attached to agents
+        as persistent context.
+      parameters:
+      - description: Memory creation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/main.CreateMemoryRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Memory created
+          schema:
+            $ref: '#/definitions/main.MemoryResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create memory
+      tags:
+      - memories
+  /memories/{name}:
+    delete:
+      description: Deletes the memory CR.
+      parameters:
+      - description: Memory name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Memory deleted
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete memory
+      tags:
+      - memories
+    get:
+      description: Returns the content and attached agent count for a single memory.
+      parameters:
+      - description: Memory name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Memory details
+          schema:
+            $ref: '#/definitions/main.MemoryResponse'
+        "404":
+          description: Memory not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get memory details
+      tags:
+      - memories
+    patch:
+      consumes:
+      - application/json
+      description: Updates the content or description of an existing memory.
+      parameters:
+      - description: Memory name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      - description: Fields to update
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/main.PatchMemoryRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Updated memory
+          schema:
+            $ref: '#/definitions/main.MemoryResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Patch memory
+      tags:
+      - memories
+  /namespaces:
+    get:
+      description: Returns all Kubernetes namespaces the API has access to.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of namespaces
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List namespaces
+      tags:
+      - templates
+  /offices:
+    get:
+      description: Returns all offices with their current status in the specified
+        namespace.
+      parameters:
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of offices
+          schema:
+            $ref: '#/definitions/main.OfficeListResponse'
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List offices
+      tags:
+      - offices
+  /offices/{name}:
+    delete:
+      description: Deletes the office CR and cleans up Redis event streams for all
+        member agents.
+      parameters:
+      - description: Office name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Office deleted
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Office not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete office
+      tags:
+      - offices
+    get:
+      description: Returns the current status and member list for a single office.
+      parameters:
+      - description: Office name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Office details
+          schema:
+            $ref: '#/definitions/main.OfficeResponse'
+        "404":
+          description: Office not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get office details
+      tags:
+      - offices
+  /offices/{name}/events:
+    get:
+      description: Returns merged events from all member agent Redis streams, sorted
+        chronologically.
+      parameters:
+      - description: Office name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      - default: 50
+        description: Max events to return (1-200)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Office events
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Invalid limit parameter
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Office not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get office events
+      tags:
+      - offices
+  /schedules:
+    get:
+      description: Returns all schedules with their current status and run history
+        in the specified namespace.
+      parameters:
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of schedules
+          schema:
+            $ref: '#/definitions/main.ScheduleListResponse'
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List schedules
+      tags:
+      - schedules
+    post:
+      consumes:
+      - application/json
+      description: Creates a new KomputerSchedule CR that triggers agent tasks on
+        a cron schedule.
+      parameters:
+      - description: Schedule creation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/main.CreateScheduleRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Schedule created
+          schema:
+            $ref: '#/definitions/main.ScheduleResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create schedule
+      tags:
+      - schedules
+  /schedules/{name}:
+    delete:
+      description: Deletes the schedule CR. Does not delete any agents that were created
+        by the schedule.
+      parameters:
+      - description: Schedule name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Schedule deleted
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Schedule not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete schedule
+      tags:
+      - schedules
+    get:
+      description: Returns the current status and run history for a single schedule.
+      parameters:
+      - description: Schedule name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Schedule details
+          schema:
+            $ref: '#/definitions/main.ScheduleResponse'
+        "404":
+          description: Schedule not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get schedule details
+      tags:
+      - schedules
+    patch:
+      consumes:
+      - application/json
+      description: Updates the cron expression for an existing schedule.
+      parameters:
+      - description: Schedule name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      - description: Fields to update
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/main.PatchScheduleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Updated schedule
+          schema:
+            $ref: '#/definitions/main.ScheduleResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Patch schedule
+      tags:
+      - schedules
+  /secrets:
+    get:
+      description: Returns all secrets with key names (not values) and attached agent
+        counts in the specified namespace.
+      parameters:
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      - description: Include all secrets, not just managed ones
+        in: query
+        name: all
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of secrets
+          schema:
+            $ref: '#/definitions/main.SecretListResponse'
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List secrets
+      tags:
+      - secrets
+    post:
+      consumes:
+      - application/json
+      description: Creates a new Kubernetes secret managed by komputer.ai that can
+        be attached to agents.
+      parameters:
+      - description: Secret creation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/main.CreateSecretRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Secret created
+          schema:
+            $ref: '#/definitions/main.SecretResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create managed secret
+      tags:
+      - secrets
+  /secrets/{name}:
+    delete:
+      description: Deletes a managed Kubernetes secret.
+      parameters:
+      - description: Secret name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Secret deleted
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete managed secret
+      tags:
+      - secrets
+    patch:
+      consumes:
+      - application/json
+      description: Replaces the key-value pairs in a managed Kubernetes secret.
+      parameters:
+      - description: Secret name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      - description: Updated secret data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/main.UpdateSecretRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Secret updated
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update managed secret
+      tags:
+      - secrets
+  /skills:
+    get:
+      description: Returns all skills with content and attached agent counts in the
+        specified namespace.
+      parameters:
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of skills
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List skills
+      tags:
+      - skills
+    post:
+      consumes:
+      - application/json
+      description: Creates a new KomputerSkill CR with script content that can be
+        attached to agents.
+      parameters:
+      - description: Skill creation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/main.CreateSkillRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Skill created
+          schema:
+            $ref: '#/definitions/main.SkillResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create skill
+      tags:
+      - skills
+  /skills/{name}:
+    delete:
+      description: Deletes the skill CR.
+      parameters:
+      - description: Skill name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Skill deleted
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete skill
+      tags:
+      - skills
+    get:
+      description: Returns the content, description, and attached agent count for
+        a single skill.
+      parameters:
+      - description: Skill name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Skill details
+          schema:
+            $ref: '#/definitions/main.SkillResponse'
+        "404":
+          description: Skill not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get skill details
+      tags:
+      - skills
+    patch:
+      consumes:
+      - application/json
+      description: Updates the description or script content of an existing skill.
+      parameters:
+      - description: Skill name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      - description: Fields to update
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/main.PatchSkillRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Updated skill
+          schema:
+            $ref: '#/definitions/main.SkillResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Patch skill
+      tags:
+      - skills
+  /templates:
+    get:
+      description: Returns all agent templates (both namespace-scoped and cluster-scoped)
+        available in the specified namespace.
+      parameters:
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of templates
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List agent templates
+      tags:
+      - templates
 swagger: "2.0"

--- a/komputer-api/handler_agents.go
+++ b/komputer-api/handler_agents.go
@@ -491,6 +491,19 @@ func listAgents(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// patchAgent updates fields on an existing agent.
+// @Summary Patch agent
+// @Description Updates model, lifecycle, instructions, secretRefs, memories, skills, or connectors on an existing agent.
+// @Tags agents
+// @Accept json
+// @Produce json
+// @Param name path string true "Agent name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Param request body PatchAgentRequest true "Fields to update"
+// @Success 200 {object} AgentResponse "Updated agent"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /agents/{name} [patch]
 func patchAgent(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")

--- a/komputer-api/handler_connectors.go
+++ b/komputer-api/handler_connectors.go
@@ -43,6 +43,17 @@ type mcpTool struct {
 	Description string `json:"description"`
 }
 
+// createConnector creates a new MCP connector resource.
+// @Summary Create connector
+// @Description Creates a new KomputerConnector CR pointing to an MCP server that can be attached to agents.
+// @Tags connectors
+// @Accept json
+// @Produce json
+// @Param request body CreateConnectorRequest true "Connector creation request"
+// @Success 201 {object} ConnectorResponse "Connector created"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /connectors [post]
 func createConnector(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req CreateConnectorRequest
@@ -67,6 +78,15 @@ func createConnector(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// listConnectors returns all connectors in a namespace.
+// @Summary List connectors
+// @Description Returns all connectors with attached agent counts in the specified namespace.
+// @Tags connectors
+// @Produce json
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]interface{} "List of connectors"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /connectors [get]
 func listConnectors(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ns := c.Query("namespace")
@@ -92,6 +112,17 @@ func listConnectors(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// getConnector returns details for a single connector.
+// @Summary Get connector details
+// @Description Returns the URL, service, type, and auth config for a single connector.
+// @Tags connectors
+// @Produce json
+// @Param name path string true "Connector name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} ConnectorResponse "Connector details"
+// @Failure 404 {object} map[string]string "Connector not found"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /connectors/{name} [get]
 func getConnector(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -105,6 +136,18 @@ func getConnector(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// listConnectorTools fetches the available tools from the connector's MCP server.
+// @Summary List connector tools
+// @Description Calls the MCP server's tools/list endpoint and returns the available tools.
+// @Tags connectors
+// @Produce json
+// @Param name path string true "Connector name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]interface{} "List of MCP tools"
+// @Failure 404 {object} map[string]string "Connector not found"
+// @Failure 502 {object} map[string]string "Failed to reach MCP server"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /connectors/{name}/tools [get]
 func listConnectorTools(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -226,6 +269,16 @@ func fetchMCPTools(serverURL, authHeader string) ([]mcpTool, error) {
 	return tools, nil
 }
 
+// deleteConnector deletes a connector by name.
+// @Summary Delete connector
+// @Description Deletes the connector CR.
+// @Tags connectors
+// @Produce json
+// @Param name path string true "Connector name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]string "Connector deleted"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /connectors/{name} [delete]
 func deleteConnector(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")

--- a/komputer-api/handler_memories.go
+++ b/komputer-api/handler_memories.go
@@ -29,6 +29,17 @@ type PatchMemoryRequest struct {
 	Description *string `json:"description,omitempty"`
 }
 
+// createMemory creates a new memory resource.
+// @Summary Create memory
+// @Description Creates a new KomputerMemory CR that can be attached to agents as persistent context.
+// @Tags memories
+// @Accept json
+// @Produce json
+// @Param request body CreateMemoryRequest true "Memory creation request"
+// @Success 201 {object} MemoryResponse "Memory created"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /memories [post]
 func createMemory(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req CreateMemoryRequest
@@ -59,6 +70,17 @@ func createMemory(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// getMemory returns details for a single memory.
+// @Summary Get memory details
+// @Description Returns the content and attached agent count for a single memory.
+// @Tags memories
+// @Produce json
+// @Param name path string true "Memory name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} MemoryResponse "Memory details"
+// @Failure 404 {object} map[string]string "Memory not found"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /memories/{name} [get]
 func getMemory(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -80,6 +102,15 @@ func getMemory(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// listMemories returns all memories in a namespace.
+// @Summary List memories
+// @Description Returns all memories with content and attached agent counts in the specified namespace.
+// @Tags memories
+// @Produce json
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]interface{} "List of memories"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /memories [get]
 func listMemories(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ns := c.Query("namespace") // empty = all namespaces
@@ -104,6 +135,19 @@ func listMemories(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// patchMemory updates content or description on an existing memory.
+// @Summary Patch memory
+// @Description Updates the content or description of an existing memory.
+// @Tags memories
+// @Accept json
+// @Produce json
+// @Param name path string true "Memory name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Param request body PatchMemoryRequest true "Fields to update"
+// @Success 200 {object} MemoryResponse "Updated memory"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /memories/{name} [patch]
 func patchMemory(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -138,6 +182,16 @@ func patchMemory(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// deleteMemory deletes a memory by name.
+// @Summary Delete memory
+// @Description Deletes the memory CR.
+// @Tags memories
+// @Produce json
+// @Param name path string true "Memory name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]string "Memory deleted"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /memories/{name} [delete]
 func deleteMemory(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")

--- a/komputer-api/handler_offices.go
+++ b/komputer-api/handler_offices.go
@@ -75,6 +75,15 @@ func officeToResponse(o komputerv1alpha1.KomputerOffice, includeMembers bool) Of
 	return resp
 }
 
+// listOffices returns all offices in a namespace.
+// @Summary List offices
+// @Description Returns all offices with their current status in the specified namespace.
+// @Tags offices
+// @Produce json
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} OfficeListResponse "List of offices"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /offices [get]
 func listOffices(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ns := c.Query("namespace") // empty = all namespaces
@@ -91,6 +100,17 @@ func listOffices(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// getOffice returns details for a single office including all member agents.
+// @Summary Get office details
+// @Description Returns the current status and member list for a single office.
+// @Tags offices
+// @Produce json
+// @Param name path string true "Office name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} OfficeResponse "Office details"
+// @Failure 404 {object} map[string]string "Office not found"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /offices/{name} [get]
 func getOffice(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -108,6 +128,17 @@ func getOffice(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// deleteOffice deletes an office and cleans up all member agent event streams.
+// @Summary Delete office
+// @Description Deletes the office CR and cleans up Redis event streams for all member agents.
+// @Tags offices
+// @Produce json
+// @Param name path string true "Office name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]string "Office deleted"
+// @Failure 404 {object} map[string]string "Office not found"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /offices/{name} [delete]
 func deleteOffice(k8s *K8sClient, worker *RedisWorker) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -150,6 +181,19 @@ func deleteOffice(k8s *K8sClient, worker *RedisWorker) gin.HandlerFunc {
 	}
 }
 
+// getOfficeEvents returns merged events from all member agents in the office.
+// @Summary Get office events
+// @Description Returns merged events from all member agent Redis streams, sorted chronologically.
+// @Tags offices
+// @Produce json
+// @Param name path string true "Office name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Param limit query int false "Max events to return (1-200)" default(50)
+// @Success 200 {object} map[string]interface{} "Office events"
+// @Failure 400 {object} map[string]string "Invalid limit parameter"
+// @Failure 404 {object} map[string]string "Office not found"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /offices/{name}/events [get]
 func getOfficeEvents(k8s *K8sClient, worker *RedisWorker) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")

--- a/komputer-api/handler_schedules.go
+++ b/komputer-api/handler_schedules.go
@@ -94,6 +94,17 @@ func scheduleToResponse(s komputerv1alpha1.KomputerSchedule) ScheduleResponse {
 	return resp
 }
 
+// createSchedule creates a new cron schedule that fires agents on a recurring basis.
+// @Summary Create schedule
+// @Description Creates a new KomputerSchedule CR that triggers agent tasks on a cron schedule.
+// @Tags schedules
+// @Accept json
+// @Produce json
+// @Param request body CreateScheduleRequest true "Schedule creation request"
+// @Success 201 {object} ScheduleResponse "Schedule created"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /schedules [post]
 func createSchedule(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req CreateScheduleRequest
@@ -128,6 +139,15 @@ func createSchedule(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// listSchedules returns all schedules in a namespace.
+// @Summary List schedules
+// @Description Returns all schedules with their current status and run history in the specified namespace.
+// @Tags schedules
+// @Produce json
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} ScheduleListResponse "List of schedules"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /schedules [get]
 func listSchedules(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ns := c.Query("namespace") // empty = all namespaces
@@ -144,6 +164,17 @@ func listSchedules(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// getSchedule returns details for a single schedule.
+// @Summary Get schedule details
+// @Description Returns the current status and run history for a single schedule.
+// @Tags schedules
+// @Produce json
+// @Param name path string true "Schedule name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} ScheduleResponse "Schedule details"
+// @Failure 404 {object} map[string]string "Schedule not found"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /schedules/{name} [get]
 func getSchedule(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -161,6 +192,17 @@ func getSchedule(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// deleteSchedule deletes a schedule by name.
+// @Summary Delete schedule
+// @Description Deletes the schedule CR. Does not delete any agents that were created by the schedule.
+// @Tags schedules
+// @Produce json
+// @Param name path string true "Schedule name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]string "Schedule deleted"
+// @Failure 404 {object} map[string]string "Schedule not found"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /schedules/{name} [delete]
 func deleteSchedule(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -178,6 +220,19 @@ func deleteSchedule(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// patchSchedule updates the cron expression for a schedule.
+// @Summary Patch schedule
+// @Description Updates the cron expression for an existing schedule.
+// @Tags schedules
+// @Accept json
+// @Produce json
+// @Param name path string true "Schedule name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Param request body PatchScheduleRequest true "Fields to update"
+// @Success 200 {object} ScheduleResponse "Updated schedule"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /schedules/{name} [patch]
 func patchSchedule(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")

--- a/komputer-api/handler_secrets.go
+++ b/komputer-api/handler_secrets.go
@@ -29,6 +29,21 @@ type CreateSecretRequest struct {
 	Namespace string            `json:"namespace"`
 }
 
+type UpdateSecretRequest struct {
+	Data      map[string]string `json:"data" binding:"required"`
+	Namespace string            `json:"namespace"`
+}
+
+// listSecrets returns all Kubernetes secrets in a namespace.
+// @Summary List secrets
+// @Description Returns all secrets with key names (not values) and attached agent counts in the specified namespace.
+// @Tags secrets
+// @Produce json
+// @Param namespace query string false "Kubernetes namespace"
+// @Param all query boolean false "Include all secrets, not just managed ones"
+// @Success 200 {object} SecretListResponse "List of secrets"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /secrets [get]
 func listSecrets(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ns := c.Query("namespace") // empty = all namespaces
@@ -69,6 +84,17 @@ func listSecrets(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// createManagedSecret creates a new managed Kubernetes secret.
+// @Summary Create managed secret
+// @Description Creates a new Kubernetes secret managed by komputer.ai that can be attached to agents.
+// @Tags secrets
+// @Accept json
+// @Produce json
+// @Param request body CreateSecretRequest true "Secret creation request"
+// @Success 201 {object} SecretResponse "Secret created"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /secrets [post]
 func createManagedSecret(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req CreateSecretRequest
@@ -104,6 +130,16 @@ func createManagedSecret(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// deleteManagedSecret deletes a managed secret by name.
+// @Summary Delete managed secret
+// @Description Deletes a managed Kubernetes secret.
+// @Tags secrets
+// @Produce json
+// @Param name path string true "Secret name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]string "Secret deleted"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /secrets/{name} [delete]
 func deleteManagedSecret(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -116,14 +152,24 @@ func deleteManagedSecret(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// updateManagedSecret updates the data in a managed secret.
+// @Summary Update managed secret
+// @Description Replaces the key-value pairs in a managed Kubernetes secret.
+// @Tags secrets
+// @Accept json
+// @Produce json
+// @Param name path string true "Secret name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Param request body UpdateSecretRequest true "Updated secret data"
+// @Success 200 {object} map[string]string "Secret updated"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /secrets/{name} [patch]
 func updateManagedSecret(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
 		ns := resolveNamespace(c, k8s)
-		var req struct {
-			Data      map[string]string `json:"data" binding:"required"`
-			Namespace string            `json:"namespace"`
-		}
+		var req UpdateSecretRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
 			return

--- a/komputer-api/handler_skills.go
+++ b/komputer-api/handler_skills.go
@@ -30,6 +30,17 @@ type PatchSkillRequest struct {
 	Content     *string `json:"content,omitempty"`
 }
 
+// createSkill creates a new skill resource.
+// @Summary Create skill
+// @Description Creates a new KomputerSkill CR with script content that can be attached to agents.
+// @Tags skills
+// @Accept json
+// @Produce json
+// @Param request body CreateSkillRequest true "Skill creation request"
+// @Success 201 {object} SkillResponse "Skill created"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /skills [post]
 func createSkill(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req CreateSkillRequest
@@ -61,6 +72,17 @@ func createSkill(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// getSkill returns details for a single skill.
+// @Summary Get skill details
+// @Description Returns the content, description, and attached agent count for a single skill.
+// @Tags skills
+// @Produce json
+// @Param name path string true "Skill name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} SkillResponse "Skill details"
+// @Failure 404 {object} map[string]string "Skill not found"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /skills/{name} [get]
 func getSkill(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -83,6 +105,15 @@ func getSkill(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// listSkills returns all skills in a namespace.
+// @Summary List skills
+// @Description Returns all skills with content and attached agent counts in the specified namespace.
+// @Tags skills
+// @Produce json
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]interface{} "List of skills"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /skills [get]
 func listSkills(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ns := c.Query("namespace") // empty = all namespaces
@@ -108,6 +139,19 @@ func listSkills(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// patchSkill updates description or content on an existing skill.
+// @Summary Patch skill
+// @Description Updates the description or script content of an existing skill.
+// @Tags skills
+// @Accept json
+// @Produce json
+// @Param name path string true "Skill name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Param request body PatchSkillRequest true "Fields to update"
+// @Success 200 {object} SkillResponse "Updated skill"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /skills/{name} [patch]
 func patchSkill(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -143,6 +187,16 @@ func patchSkill(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// deleteSkill deletes a skill by name.
+// @Summary Delete skill
+// @Description Deletes the skill CR.
+// @Tags skills
+// @Produce json
+// @Param name path string true "Skill name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]string "Skill deleted"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /skills/{name} [delete]
 func deleteSkill(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")

--- a/komputer-api/handler_templates.go
+++ b/komputer-api/handler_templates.go
@@ -12,6 +12,15 @@ type TemplateResponse struct {
 	Namespace string `json:"namespace,omitempty"` // populated for namespaced templates
 }
 
+// listTemplates returns available agent templates in the namespace and cluster.
+// @Summary List agent templates
+// @Description Returns all agent templates (both namespace-scoped and cluster-scoped) available in the specified namespace.
+// @Tags templates
+// @Produce json
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} map[string]interface{} "List of templates"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /templates [get]
 func listTemplates(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ns := resolveNamespace(c, k8s)
@@ -29,6 +38,14 @@ func listTemplates(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// listNamespaces returns all Kubernetes namespaces accessible to the API.
+// @Summary List namespaces
+// @Description Returns all Kubernetes namespaces the API has access to.
+// @Tags templates
+// @Produce json
+// @Success 200 {object} map[string]interface{} "List of namespaces"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /namespaces [get]
 func listNamespaces(k8s *K8sClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		names, err := k8s.ListNamespaces(c.Request.Context())


### PR DESCRIPTION
## Summary

- Added swagger annotations to all handler functions that were missing them
- Previously only agent routes were documented; now all 21 API paths are covered
- Covers: offices, schedules, memories, skills, secrets, connectors, templates, namespaces
- Regenerated docs/ with swag init

## Test plan

- [x] `go build .` passes
- [x] swagger.json contains all 21 API paths
- [ ] Swagger UI renders correctly at /swagger/