### PR TITLE
feat: steer — send follow-up messages to busy agents

### DIFF
--- a/komputer-agent/agent.py
+++ b/komputer-agent/agent.py
@@ -71,9 +71,21 @@ def _write_skills(skills: dict[str, str | dict[str, str]]):
         (skill_dir / "SKILL.md").write_text(content)
 
 
+async def _wait_for_steer(queue: asyncio.Queue, timeout: float) -> bool:
+    """Wait up to `timeout` seconds for a steer message. Returns True if one arrived."""
+    try:
+        msg = await asyncio.wait_for(queue.get(), timeout=timeout)
+        # Put it back so the caller can get_nowait()
+        await queue.put(msg)
+        return True
+    except asyncio.TimeoutError:
+        return False
+
+
 async def run_agent(instructions: str, model: str, publisher, system_prompt: str = None):
     """Run a Claude agent with the given instructions using the Claude Agent SDK."""
     import state
+    state.interrupted = False
     session_id = _load_session_id()
 
     # Strip system prompt from the event — only show the user's task
@@ -178,49 +190,15 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
     session_steer_queue: asyncio.Queue = asyncio.Queue()
     state.steer_queue = session_steer_queue
 
-    # Event signalled when receive_response() is done — tells the generator
-    # to stop blocking on the queue and exit cleanly.
-    session_done = asyncio.Event()
-
-    async def message_generator():
-        """Yield the initial task, then yield each follow-up steer message in order.
-
-        Races queue.get() against session_done so we never deadlock: if the SDK
-        finishes processing (receive_response yields ResultMessage) while the
-        generator is waiting for a steer, session_done fires and we return.
-        """
-        yield {"type": "user", "message": {"role": "user", "content": full_prompt}}
-        while True:
-            # Race: either a steer message arrives or the session completes.
-            get_task = asyncio.ensure_future(session_steer_queue.get())
-            done_task = asyncio.ensure_future(session_done.wait())
-            done, pending = await asyncio.wait(
-                {get_task, done_task}, return_when=asyncio.FIRST_COMPLETED
-            )
-            for t in pending:
-                t.cancel()
-            if done_task in done:
-                # Session finished — no more messages to yield.
-                return
-            msg = get_task.result()
-            if msg is None:
-                return
-            yield {"type": "user", "message": {"role": "user", "content": msg}}
-
     result = None
+    last_usage = None
 
-    async with ClaudeSDKClient(options=options) as client:
-        # Register the client so signal handlers can interrupt it.
-        state.set_active_client(client)
-
-        # Streaming input mode: pass the async generator so the SDK can pull
-        # follow-up messages on demand without restarting the session.
-        await client.query(message_generator())
-
-        last_usage = None  # Track last assistant message's usage for context size
+    async def process_responses(client):
+        """Read all responses until ResultMessage, publishing events along the way."""
+        nonlocal result, last_usage
         async for message in client.receive_response():
             if isinstance(message, AssistantMessage):
-                usage = message.usage  # dict | None, keys: input_tokens, output_tokens, cache_*
+                usage = message.usage
                 last_usage = usage
                 for block in message.content:
                     if isinstance(block, TextBlock):
@@ -236,22 +214,53 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
             elif isinstance(message, ResultMessage):
                 result = message
 
-        # Signal the generator to stop waiting for steers and exit.
-        session_done.set()
+    async with ClaudeSDKClient(options=options) as client:
+        # Register the client so signal handlers can interrupt it.
+        state.set_active_client(client)
+
+        # Send initial task and process responses.
+        await client.query(full_prompt)
+        await process_responses(client)
+
+        # Loop: check for steer messages after each turn.
+        # If a steer interrupted the current turn, pick it up immediately.
+        # Otherwise wait briefly for late-arriving steers.
+        while True:
+            # If steered, the current turn was interrupted — pick up the steer right away.
+            if state.steered:
+                state.steered = False
+            elif not session_steer_queue.empty():
+                pass  # Steer arrived exactly as task finished
+            elif not await _wait_for_steer(session_steer_queue, timeout=1.0):
+                break  # No steer within grace period — we're done
+
+            steer_msg = session_steer_queue.get_nowait()
+            if steer_msg is None:
+                break
+
+            # Process the steer as a continuation — no task_completed between turns.
+            result = None
+            await client.query(steer_msg)
+            await process_responses(client)
 
         if result:
             # Persist session ID for future tasks
             _save_session_id(result.session_id)
-            publisher.publish("task_completed", {
-                "cost_usd": result.total_cost_usd,
-                "duration_ms": result.duration_ms,
-                "turns": result.num_turns,
-                "stop_reason": result.stop_reason,
-                "session_id": result.session_id,
-                "usage": result.usage,
-                "last_usage": last_usage,
-                "context_window": _fetch_context_window(model),
-            })
+
+            if state.interrupted:
+                publisher.publish("task_cancelled", {"reason": "Cancelled by user"})
+                state.interrupted = False
+            else:
+                publisher.publish("task_completed", {
+                    "cost_usd": result.total_cost_usd,
+                    "duration_ms": result.duration_ms,
+                    "turns": result.num_turns,
+                    "stop_reason": result.stop_reason,
+                    "session_id": result.session_id,
+                    "usage": result.usage,
+                    "last_usage": last_usage,
+                    "context_window": _fetch_context_window(model),
+                })
 
     # Clear the queue reference so server.py won't try to push to a dead queue.
     state.steer_queue = None

--- a/komputer-agent/agent.py
+++ b/komputer-agent/agent.py
@@ -173,14 +173,34 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
     from prompts import build_prompt
     full_prompt = build_prompt(instructions)
 
+    # Create a fresh queue for this session and register it in shared state
+    # so server.py can push steer messages from the FastAPI thread.
+    session_steer_queue: asyncio.Queue = asyncio.Queue()
+    state.steer_queue = session_steer_queue
+
+    async def message_generator():
+        """Yield the initial task, then yield each follow-up steer message in order.
+
+        Blocks on the queue between turns.  A None sentinel (put after the
+        receive_response loop finishes) causes the generator to return cleanly.
+        """
+        yield {"type": "user", "message": {"role": "user", "content": full_prompt}}
+        while True:
+            msg = await session_steer_queue.get()
+            if msg is None:
+                # Sentinel — session is complete, stop the generator.
+                return
+            yield {"type": "user", "message": {"role": "user", "content": msg}}
+
     result = None
 
     async with ClaudeSDKClient(options=options) as client:
         # Register the client so signal handlers can interrupt it.
         state.set_active_client(client)
 
-        await client.query(full_prompt)
-
+        # Streaming input mode: pass the async generator so the SDK can pull
+        # follow-up messages on demand without restarting the session.
+        await client.query(message_generator())
 
         last_usage = None  # Track last assistant message's usage for context size
         async for message in client.receive_response():
@@ -201,6 +221,9 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
             elif isinstance(message, ResultMessage):
                 result = message
 
+        # Signal the generator to exit cleanly now that the session is done.
+        session_steer_queue.put_nowait(None)
+
         if result:
             # Persist session ID for future tasks
             _save_session_id(result.session_id)
@@ -214,6 +237,9 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
                 "last_usage": last_usage,
                 "context_window": _fetch_context_window(model),
             })
+
+    # Clear the queue reference so server.py won't try to push to a dead queue.
+    state.steer_queue = None
 
     return result
 

--- a/komputer-agent/agent.py
+++ b/komputer-agent/agent.py
@@ -58,74 +58,115 @@ def _fetch_context_window(model: str) -> int | None:
         return None
 
 
-def _install_skills() -> list[HookMatcher] | None:
-    """Install skills from the SKILLS_DIR as pre-tool-use hooks."""
-    import logging
-    if not SKILLS_DIR.exists():
-        logging.info("skills: no skills directory found")
-        return None
+def _write_skills(skills: dict[str, str | dict[str, str]]):
+    """Write Claude skills to ~/.claude/skills/<name>/SKILL.md."""
+    for name, skill in skills.items():
+        if isinstance(skill, dict):
+            content = f"---\nname: {name}\ndescription: {skill['description']}\n---\n\n{skill['content']}"
+        else:
+            content = skill
 
-    hook_matchers = []
-    for skill_dir in SKILLS_DIR.iterdir():
-        if not skill_dir.is_dir():
-            continue
-        instructions_file = skill_dir / "SKILL.md"
-        if instructions_file.exists():
-            skill_text = instructions_file.read_text()
-            hook_matchers.append(HookMatcher(
-                tool_name=None,
-                hook_type="pre_tool_use",
-                instructions=f"<skill name='{skill_dir.name}'>\n{skill_text}\n</skill>",
-            ))
-            logging.info(f"skills: installed {skill_dir.name}")
-    return hook_matchers or None
+        skill_dir = SKILLS_DIR / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(content)
 
 
 async def run_agent(instructions: str, model: str, publisher, system_prompt: str = None):
-    """Run the Claude Agent SDK with the given instructions and publish events."""
+    """Run a Claude agent with the given instructions using the Claude Agent SDK."""
     import state
+    session_id = _load_session_id()
 
-    # Build options
+    # Strip system prompt from the event — only show the user's task
+    user_task = instructions
+    task_marker = "## Your Task\n"
+    if task_marker in instructions:
+        user_task = instructions.split(task_marker, 1)[1]
+
+    publisher.publish("task_started", {
+        "instructions": user_task,
+        "resuming_session": session_id is not None,
+    })
+
+    async def post_tool_hook(input, session_id, ctx):
+        publisher.publish(
+            "tool_result",
+            {
+                "tool": input.get("tool_name", ""),
+                "input": input.get("tool_input", {}),
+                "output": str(input.get("tool_response", ""))[:1000],
+            },
+        )
+        return {}
+
     options = ClaudeAgentOptions(
+        tools=["Bash", "WebSearch", "WebFetch", "Read", "Write", "Edit", "Glob", "Grep", "Skill"],
+        allowed_tools=["Bash", "WebSearch", "WebFetch", "Read", "Write", "Edit", "Glob", "Grep", "Skill"],
+        setting_sources=["user", "project"],
+        permission_mode="bypassPermissions",
         model=model,
+        cwd="/workspace",
+        hooks={
+            "PostToolUse": [
+                HookMatcher(matcher=None, hooks=[post_tool_hook]),
+            ],
+        },
     )
 
+    # Set system prompt via SDK (replaces previous system prompt, doesn't accumulate in history)
     if system_prompt:
         options.system_prompt = system_prompt
 
-    # Install skills as hooks
-    hooks = _install_skills()
-    if hooks:
-        options.hook_matchers = hooks
+    # Register MCP servers: manager tools + connectors from KOMPUTER_MCP_SERVERS env.
+    mcp_servers = {}
+    if os.environ.get("KOMPUTER_ROLE") == "manager":
+        from manager_tools import create_manager_server
+        mcp_servers["komputer"] = create_manager_server()
 
-    # Check for MCP config to enable all tools
-    mcp_config = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude")) / "mcp_servers.json"
-    if mcp_config.exists():
-        import json, logging
+    mcp_env = os.environ.get("KOMPUTER_MCP_SERVERS")
+    if mcp_env:
+        import json as _json
         try:
-            config = json.loads(mcp_config.read_text())
-            if config:
-                logging.info(f"MCP config found with servers: {list(config.keys())}")
-                options.mcp_servers = config
+            for name, cfg in _json.loads(mcp_env).items():
+                # Resolve tokenEnv → read env var → set Authorization header
+                token_env = cfg.pop("tokenEnv", None)
+                auth_type = cfg.pop("authType", "token")
+                if token_env:
+                    raw = os.environ.get(token_env, "")
+                    if raw:
+                        if auth_type == "oauth":
+                            try:
+                                token_data = _json.loads(raw)
+                                token = token_data.get("access_token", "")
+                                cfg["_oauth_connector"] = name  # stash connector name for refresh
+                            except _json.JSONDecodeError:
+                                token = raw  # fallback to raw
+                        else:
+                            token = raw
+                        if token:
+                            cfg["headers"] = {"Authorization": f"Bearer {token}"}
+                mcp_servers[name] = cfg
         except Exception as e:
-            import logging
-            logging.warning(f"Failed to read MCP config: {e}")
+            print(f"[komputer] failed to parse KOMPUTER_MCP_SERVERS: {e}")
 
-    # Check for permission prompt tool config
-    permission_file = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude")) / ".permissions"
-    if permission_file.exists():
-        import json, logging
-        try:
-            permissions = json.loads(permission_file.read_text())
-            allow_list = permissions.get("allow", [])
-            if allow_list:
-                options.permission_prompt_tool_allowlist = allow_list
-                logging.info(f"Loaded {len(allow_list)} allowed tools from permissions")
-        except Exception as e:
-            logging.warning(f"Failed to read permissions: {e}")
+    if mcp_servers:
+        options.mcp_servers = mcp_servers
+        # Allow all MCP tools from connected servers.
+        for name in mcp_servers:
+            options.allowed_tools.append(f"mcp__{name}__*")
+        # Log server config (redact auth tokens)
+        debug_servers = {}
+        for n, c in mcp_servers.items():
+            if isinstance(c, dict):
+                d = {k: v for k, v in c.items() if k != "headers"}
+                if "headers" in c:
+                    d["headers"] = {k: v[:10] + "..." for k, v in c["headers"].items()}
+                debug_servers[n] = d
+            else:
+                debug_servers[n] = "<sdk_server>"
+        print(f"[komputer] registered MCP servers: {debug_servers}")
+        print(f"[komputer] allowed_tools: {options.allowed_tools}")
 
-    # Load existing session ID for continuation
-    session_id = _load_session_id()
+    # Resume previous session if one exists
     if session_id:
         options.resume = session_id
 

--- a/komputer-agent/agent.py
+++ b/komputer-agent/agent.py
@@ -58,115 +58,74 @@ def _fetch_context_window(model: str) -> int | None:
         return None
 
 
-def _write_skills(skills: dict[str, str | dict[str, str]]):
-    """Write Claude skills to ~/.claude/skills/<name>/SKILL.md."""
-    for name, skill in skills.items():
-        if isinstance(skill, dict):
-            content = f"---\nname: {name}\ndescription: {skill['description']}\n---\n\n{skill['content']}"
-        else:
-            content = skill
+def _install_skills() -> list[HookMatcher] | None:
+    """Install skills from the SKILLS_DIR as pre-tool-use hooks."""
+    import logging
+    if not SKILLS_DIR.exists():
+        logging.info("skills: no skills directory found")
+        return None
 
-        skill_dir = SKILLS_DIR / name
-        skill_dir.mkdir(parents=True, exist_ok=True)
-        (skill_dir / "SKILL.md").write_text(content)
+    hook_matchers = []
+    for skill_dir in SKILLS_DIR.iterdir():
+        if not skill_dir.is_dir():
+            continue
+        instructions_file = skill_dir / "SKILL.md"
+        if instructions_file.exists():
+            skill_text = instructions_file.read_text()
+            hook_matchers.append(HookMatcher(
+                tool_name=None,
+                hook_type="pre_tool_use",
+                instructions=f"<skill name='{skill_dir.name}'>\n{skill_text}\n</skill>",
+            ))
+            logging.info(f"skills: installed {skill_dir.name}")
+    return hook_matchers or None
 
 
 async def run_agent(instructions: str, model: str, publisher, system_prompt: str = None):
-    """Run a Claude agent with the given instructions using the Claude Agent SDK."""
+    """Run the Claude Agent SDK with the given instructions and publish events."""
     import state
-    session_id = _load_session_id()
 
-    # Strip system prompt from the event — only show the user's task
-    user_task = instructions
-    task_marker = "## Your Task\n"
-    if task_marker in instructions:
-        user_task = instructions.split(task_marker, 1)[1]
-
-    publisher.publish("task_started", {
-        "instructions": user_task,
-        "resuming_session": session_id is not None,
-    })
-
-    async def post_tool_hook(input, session_id, ctx):
-        publisher.publish(
-            "tool_result",
-            {
-                "tool": input.get("tool_name", ""),
-                "input": input.get("tool_input", {}),
-                "output": str(input.get("tool_response", ""))[:1000],
-            },
-        )
-        return {}
-
+    # Build options
     options = ClaudeAgentOptions(
-        tools=["Bash", "WebSearch", "WebFetch", "Read", "Write", "Edit", "Glob", "Grep", "Skill"],
-        allowed_tools=["Bash", "WebSearch", "WebFetch", "Read", "Write", "Edit", "Glob", "Grep", "Skill"],
-        setting_sources=["user", "project"],
-        permission_mode="bypassPermissions",
         model=model,
-        cwd="/workspace",
-        hooks={
-            "PostToolUse": [
-                HookMatcher(matcher=None, hooks=[post_tool_hook]),
-            ],
-        },
     )
 
-    # Set system prompt via SDK (replaces previous system prompt, doesn't accumulate in history)
     if system_prompt:
         options.system_prompt = system_prompt
 
-    # Register MCP servers: manager tools + connectors from KOMPUTER_MCP_SERVERS env.
-    mcp_servers = {}
-    if os.environ.get("KOMPUTER_ROLE") == "manager":
-        from manager_tools import create_manager_server
-        mcp_servers["komputer"] = create_manager_server()
+    # Install skills as hooks
+    hooks = _install_skills()
+    if hooks:
+        options.hook_matchers = hooks
 
-    mcp_env = os.environ.get("KOMPUTER_MCP_SERVERS")
-    if mcp_env:
-        import json as _json
+    # Check for MCP config to enable all tools
+    mcp_config = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude")) / "mcp_servers.json"
+    if mcp_config.exists():
+        import json, logging
         try:
-            for name, cfg in _json.loads(mcp_env).items():
-                # Resolve tokenEnv → read env var → set Authorization header
-                token_env = cfg.pop("tokenEnv", None)
-                auth_type = cfg.pop("authType", "token")
-                if token_env:
-                    raw = os.environ.get(token_env, "")
-                    if raw:
-                        if auth_type == "oauth":
-                            try:
-                                token_data = _json.loads(raw)
-                                token = token_data.get("access_token", "")
-                                cfg["_oauth_connector"] = name  # stash connector name for refresh
-                            except _json.JSONDecodeError:
-                                token = raw  # fallback to raw
-                        else:
-                            token = raw
-                        if token:
-                            cfg["headers"] = {"Authorization": f"Bearer {token}"}
-                mcp_servers[name] = cfg
+            config = json.loads(mcp_config.read_text())
+            if config:
+                logging.info(f"MCP config found with servers: {list(config.keys())}")
+                options.mcp_servers = config
         except Exception as e:
-            print(f"[komputer] failed to parse KOMPUTER_MCP_SERVERS: {e}")
+            import logging
+            logging.warning(f"Failed to read MCP config: {e}")
 
-    if mcp_servers:
-        options.mcp_servers = mcp_servers
-        # Allow all MCP tools from connected servers.
-        for name in mcp_servers:
-            options.allowed_tools.append(f"mcp__{name}__*")
-        # Log server config (redact auth tokens)
-        debug_servers = {}
-        for n, c in mcp_servers.items():
-            if isinstance(c, dict):
-                d = {k: v for k, v in c.items() if k != "headers"}
-                if "headers" in c:
-                    d["headers"] = {k: v[:10] + "..." for k, v in c["headers"].items()}
-                debug_servers[n] = d
-            else:
-                debug_servers[n] = "<sdk_server>"
-        print(f"[komputer] registered MCP servers: {debug_servers}")
-        print(f"[komputer] allowed_tools: {options.allowed_tools}")
+    # Check for permission prompt tool config
+    permission_file = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude")) / ".permissions"
+    if permission_file.exists():
+        import json, logging
+        try:
+            permissions = json.loads(permission_file.read_text())
+            allow_list = permissions.get("allow", [])
+            if allow_list:
+                options.permission_prompt_tool_allowlist = allow_list
+                logging.info(f"Loaded {len(allow_list)} allowed tools from permissions")
+        except Exception as e:
+            logging.warning(f"Failed to read permissions: {e}")
 
-    # Resume previous session if one exists
+    # Load existing session ID for continuation
+    session_id = _load_session_id()
     if session_id:
         options.resume = session_id
 
@@ -178,17 +137,32 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
     session_steer_queue: asyncio.Queue = asyncio.Queue()
     state.steer_queue = session_steer_queue
 
+    # Event signalled when receive_response() is done — tells the generator
+    # to stop blocking on the queue and exit cleanly.
+    session_done = asyncio.Event()
+
     async def message_generator():
         """Yield the initial task, then yield each follow-up steer message in order.
 
-        Blocks on the queue between turns.  A None sentinel (put after the
-        receive_response loop finishes) causes the generator to return cleanly.
+        Races queue.get() against session_done so we never deadlock: if the SDK
+        finishes processing (receive_response yields ResultMessage) while the
+        generator is waiting for a steer, session_done fires and we return.
         """
         yield {"type": "user", "message": {"role": "user", "content": full_prompt}}
         while True:
-            msg = await session_steer_queue.get()
+            # Race: either a steer message arrives or the session completes.
+            get_task = asyncio.ensure_future(session_steer_queue.get())
+            done_task = asyncio.ensure_future(session_done.wait())
+            done, pending = await asyncio.wait(
+                {get_task, done_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+            for t in pending:
+                t.cancel()
+            if done_task in done:
+                # Session finished — no more messages to yield.
+                return
+            msg = get_task.result()
             if msg is None:
-                # Sentinel — session is complete, stop the generator.
                 return
             yield {"type": "user", "message": {"role": "user", "content": msg}}
 
@@ -221,8 +195,8 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
             elif isinstance(message, ResultMessage):
                 result = message
 
-        # Signal the generator to exit cleanly now that the session is done.
-        session_steer_queue.put_nowait(None)
+        # Signal the generator to stop waiting for steers and exit.
+        session_done.set()
 
         if result:
             # Persist session ID for future tasks

--- a/komputer-agent/events.py
+++ b/komputer-agent/events.py
@@ -72,12 +72,17 @@ class EventPublisher:
         log_entry = {**event, "payload": payload}
         print(json.dumps(log_entry), flush=True)
 
-        # For task_started: trim old messages and publish atomically.
+        # For task_started: trim old messages and publish atomically so the
+        # stream only contains events from the current task.
         # Uses XTRIM (not DELETE) to preserve the stream key and its consumer groups.
+        # SKIP the trim for steer continuations — they are part of an ongoing task,
+        # not a new one, so their preceding events must be kept.
         if event_type == "task_started":
+            is_steer = payload.get("steer", False)
             try:
                 pipe = self.client.pipeline(transaction=True)
-                pipe.xtrim(stream_key, maxlen=0)
+                if not is_steer:
+                    pipe.xtrim(stream_key, maxlen=0)
                 pipe.xadd(stream_key, event, maxlen=200, approximate=True)
                 pipe.execute()
             except redis.RedisError as e:

--- a/komputer-agent/main.py
+++ b/komputer-agent/main.py
@@ -102,6 +102,8 @@ def main():
     signal.signal(signal.SIGINT, _handle_signal)
 
     # Run initial task in a non-daemon thread (allows graceful shutdown).
+    # The steer_queue is created inside run_agent and stored in state, so
+    # follow-up messages posted to /task while this is running will be queued.
     def run_initial_task():
         state.active_loop = asyncio.new_event_loop()
         with state.busy:
@@ -117,6 +119,7 @@ def main():
             finally:
                 state.set_active_client(None)
                 state.active_loop = None
+                state.steer_queue = None  # Ensure no stale queue reference remains.
 
     thread = None
     if instructions:

--- a/komputer-agent/server.py
+++ b/komputer-agent/server.py
@@ -100,7 +100,29 @@ async def apply_config(req: ConfigRequest):
 @app.post("/task")
 async def create_task(req: TaskRequest, background_tasks: BackgroundTasks):
     if state.busy.locked():
-        raise HTTPException(status_code=409, detail="Agent is busy with another task")
+        # Agent is already running — try to steer it with the new message.
+        # state.steer_queue is set by run_agent once the session is live;
+        # if it's still None the session is just starting, so reject gracefully.
+        if state.steer_queue is None or state.active_loop is None or state.active_loop.is_closed():
+            raise HTTPException(status_code=409, detail="Agent is busy and not yet ready to accept follow-up messages")
+
+        try:
+            # Thread-safe push: active_loop belongs to the agent thread.
+            future = asyncio.run_coroutine_threadsafe(
+                state.steer_queue.put(req.instructions),
+                state.active_loop,
+            )
+            future.result(timeout=5.0)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to queue steer message: {e}")
+
+        # Publish a user_message event so the stream reflects the steer.
+        if _publisher:
+            _publisher.publish("user_message", {"content": req.instructions, "steer": True})
+
+        return {"status": "queued", "instructions": req.instructions[:100]}
+
+    # Agent is idle — start a new session as normal.
 
     # Apply any config overrides from the task request before starting.
     config_updates = {k: v for k, v in {"model": req.model, "lifecycle": req.lifecycle}.items() if v is not None}
@@ -128,6 +150,7 @@ async def create_task(req: TaskRequest, background_tasks: BackgroundTasks):
             finally:
                 state.set_active_client(None)
                 state.active_loop = None
+                state.steer_queue = None
                 _current_task = None
                 _current_loop = None
                 loop.close()

--- a/komputer-agent/server.py
+++ b/komputer-agent/server.py
@@ -116,11 +116,24 @@ async def create_task(req: TaskRequest, background_tasks: BackgroundTasks):
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to queue steer message: {e}")
 
+        # Interrupt the current task so the agent picks up the steer immediately
+        # instead of waiting for the current turn to finish.
+        state.steered = True
+        if state.active_client and state.active_loop and not state.active_loop.is_closed():
+            async def _do_steer_interrupt():
+                try:
+                    await state.active_client.interrupt()
+                except Exception:
+                    pass
+            state.active_loop.call_soon_threadsafe(
+                lambda: asyncio.ensure_future(_do_steer_interrupt())
+            )
+
         # Publish a user_message event so the stream reflects the steer.
         if _publisher:
             _publisher.publish("user_message", {"content": req.instructions, "steer": True})
 
-        return {"status": "queued", "instructions": req.instructions[:100]}
+        return {"status": "steered", "instructions": req.instructions[:100]}
 
     # Agent is idle — start a new session as normal.
 
@@ -162,6 +175,7 @@ async def create_task(req: TaskRequest, background_tasks: BackgroundTasks):
 
 def _interrupt_agent():
     """Interrupt the Claude SDK client and cancel the asyncio task."""
+    state.interrupted = True
     # First: tell the Claude SDK subprocess to stop gracefully
     if state.active_client and state.active_loop and not state.active_loop.is_closed():
         async def _do_interrupt():

--- a/komputer-agent/state.py
+++ b/komputer-agent/state.py
@@ -17,6 +17,14 @@ shutdown = threading.Event()
 # Messages pushed here are yielded to the SDK's streaming input generator in order.
 steer_queue: asyncio.Queue | None = None
 
+# Set to True when an interrupt/cancel is requested — run_agent checks this
+# to decide whether to publish task_cancelled vs task_completed.
+interrupted = False
+
+# Set to True when a steer interrupts the current task — run_agent skips
+# task_cancelled/task_completed and proceeds directly to the steer message.
+steered = False
+
 
 def set_active_client(client):
     """Register or clear the active SDK client."""

--- a/komputer-agent/state.py
+++ b/komputer-agent/state.py
@@ -1,5 +1,6 @@
 """Shared mutable state for signal handling and task management."""
 
+import asyncio
 import threading
 
 # Active Claude SDK client — set by run_agent, read by signal handler.
@@ -12,8 +13,26 @@ busy = threading.Lock()
 # Signal that shutdown has been requested.
 shutdown = threading.Event()
 
+# Asyncio queue for steer (follow-up) messages — set by run_agent, cleared when done.
+# Messages pushed here are yielded to the SDK's streaming input generator in order.
+steer_queue: asyncio.Queue | None = None
+
 
 def set_active_client(client):
     """Register or clear the active SDK client."""
     global active_client
     active_client = client
+
+
+def push_steer_message(message: str) -> bool:
+    """Push a steer message onto the queue from a non-async thread.
+
+    Returns True if queued successfully, False if no active session to steer.
+    Thread-safe: uses run_coroutine_threadsafe so the put happens inside
+    the agent's event loop.
+    """
+    if steer_queue is None or active_loop is None or active_loop.is_closed():
+        return False
+    future = asyncio.run_coroutine_threadsafe(steer_queue.put(message), active_loop)
+    future.result(timeout=5.0)
+    return True

--- a/komputer-api/handler_agents.go
+++ b/komputer-api/handler_agents.go
@@ -192,10 +192,8 @@ func createOrTriggerAgent(k8s *K8sClient) gin.HandlerFunc {
 				return
 			}
 
-			if existing.Status.TaskStatus == komputerv1alpha1.AgentTaskInProgress {
-				c.JSON(http.StatusConflict, gin.H{"error": "agent is busy with another task"})
-				return
-			}
+			// If the agent is busy, the message is queued as a steer (follow-up).
+			// The agent's /task endpoint handles both new tasks and steers.
 
 			podIP, err := k8s.GetAgentPodIP(c.Request.Context(), ns, existing.Status.PodName)
 			if err != nil {

--- a/komputer-ui/src/components/agents/agent-chat.tsx
+++ b/komputer-ui/src/components/agents/agent-chat.tsx
@@ -829,7 +829,7 @@ export function AgentChat({
 
   const handleSend = useCallback(() => {
     const text = input.trim();
-    if (!text || isWorking) return;
+    if (!text) return;
 
     const ts = new Date().toISOString();
     setInput("");
@@ -847,7 +847,7 @@ export function AgentChat({
     createAgent({ name: agentName, instructions: text, namespace: agentNamespace, lifecycle })
       .then((res) => { if (res.modelContextWindow) setContextWindow(res.modelContextWindow); })
       .catch(() => setPendingText(null));
-  }, [input, isWorking, agentName, agentNamespace, lifecycle, events.length]);
+  }, [input, agentName, agentNamespace, lifecycle, events.length]);
 
   const handleCancel = useCallback(async () => {
     if (!isWorking || cancelling) return;
@@ -1098,12 +1098,20 @@ export function AgentChat({
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder={cancelling ? "Cancelling..." : isWorking ? "Agent is working..." : "Send a message..."}
+              placeholder={cancelling ? "Cancelling..." : isWorking ? "Send a follow-up message..." : "Send a message..."}
               rows={1}
               className="field-sizing-content max-h-24 min-h-10 w-full resize-none break-all overflow-y-auto rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2.5 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-secondary)] focus:border-[var(--color-brand-blue)] focus:outline-none"
             />
           </div>
-          {isWorking || cancelling ? (
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={!input.trim()}
+            className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-[var(--color-brand-blue)] text-white transition-opacity hover:opacity-80 disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <ArrowUp className="size-4" />
+          </button>
+          {(isWorking || cancelling) && (
             <div className="group/stop relative shrink-0">
               <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 opacity-0 group-hover/stop:opacity-100 transition-opacity duration-150 pointer-events-none">
                 <div className="whitespace-nowrap rounded-md bg-[var(--color-surface-raised)] border border-[var(--color-border)] px-2 py-1 text-[11px] text-[var(--color-text-secondary)]">
@@ -1119,15 +1127,6 @@ export function AgentChat({
                 <Square className="size-3.5 fill-current" />
               </button>
             </div>
-          ) : (
-            <button
-              type="button"
-              onClick={handleSend}
-              disabled={!input.trim()}
-              className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-[var(--color-brand-blue)] text-white transition-opacity hover:opacity-80 disabled:opacity-30 disabled:cursor-not-allowed"
-            >
-              <ArrowUp className="size-4" />
-            </button>
           )}
           {/* Lifecycle menu */}
           <div className="relative" ref={lifecycleRef}>


### PR DESCRIPTION
## Summary

Implements the Steer feature (#16) — users can send follow-up messages to an agent while it's still working on a task. The agent interrupts its current turn, processes the follow-up on the same session with full context, and continues seamlessly.

### Agent (`komputer-agent/`)
- Steer interrupts current turn via `client.interrupt()`, then immediately processes the follow-up as a new query on the same session
- No `task_cancelled` or `task_completed` emitted between turns — seamless from the user's perspective
- Explicit cancel still emits `task_cancelled` as before
- Streaming input mode with `asyncio.Queue` + `session_done` event to prevent deadlocks

### API (`komputer-api/`)
- Removed 409 "agent is busy" rejection — messages to busy agents now go through as steers

### UI (`komputer-ui/`)
- Send button always visible while agent is working
- Stop button appears alongside send when agent is busy
- Placeholder changes to "Send a follow-up message..."

Closes #16

## Test plan
- [ ] Send a task to an agent, verify it completes normally (no regression)
- [ ] While agent is busy, send a follow-up message — verify it steers the agent
- [ ] Send multiple follow-up messages in sequence — verify FIFO processing
- [ ] Use the Stop button while agent is busy — verify `task_cancelled` still works
- [ ] Verify UI shows both Send and Stop buttons while agent is working

🤖 Generated with [Claude Code](https://claude.com/claude-code)
