### PR TITLE
ui: agent details cogwheel + agents page bulk-select

### DIFF
--- a/komputer-ui/src/app/agents/[name]/page.tsx
+++ b/komputer-ui/src/app/agents/[name]/page.tsx
@@ -3,11 +3,10 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
-import { Ban, Trash2, Zap, Moon, Save, Check, Plus, ChevronRight } from "lucide-react";
+import { Ban, Trash2, Zap, Moon, Save, Check, Plus, ChevronRight, Settings as SettingsIcon, MessageCircle, ArrowLeft } from "lucide-react";
 import { CreateSecretModal } from "@/components/secrets/create-secret-modal";
 import { Button } from "@/components/kit/button";
 import { Badge } from "@/components/kit/badge";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/kit/tabs";
 import { StatusBadge } from "@/components/shared/status-badge";
 import { CostBadge } from "@/components/shared/cost-badge";
 import { RelativeTime } from "@/components/shared/relative-time";
@@ -52,7 +51,15 @@ export default function AgentDetailPage() {
   const taskTo = taskToRef.current;
   const taskEvents = taskEventsRef.current;
 
-  const [activeTab, setActiveTab] = useState(searchParams.get("tab") === "info" ? "info" : "chat");
+  const [view, setView] = useState<"chat" | "settings">(searchParams.get("tab") === "info" ? "settings" : "chat");
+
+  const setViewAndUrl = useCallback((next: "chat" | "settings") => {
+    setView(next);
+    const params = new URLSearchParams(window.location.search);
+    if (next === "chat") { params.delete("tab"); } else { params.set("tab", "info"); }
+    const qs = params.toString();
+    window.history.replaceState(null, "", `${window.location.pathname}${qs ? `?${qs}` : ""}`);
+  }, []);
   const [agent, setAgent] = useState<AgentResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const showLoading = useDelayedLoading(loading);
@@ -298,46 +305,35 @@ export default function AgentDetailPage() {
       className="flex h-full flex-col"
     >
       {/* Unified header */}
-      <Tabs
-        defaultValue="chat"
-        value={activeTab}
-        onValueChange={(val) => {
-          setActiveTab(val);
-          const params = new URLSearchParams(window.location.search);
-          if (val === "chat") { params.delete("tab"); } else { params.set("tab", val); }
-          const qs = params.toString();
-          window.history.replaceState(null, "", `${window.location.pathname}${qs ? `?${qs}` : ""}`);
-        }}
-        className="flex flex-1 flex-col overflow-hidden"
-      >
-        <div className="shrink-0 border-b border-[var(--color-border)] bg-[var(--color-bg)] px-6">
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="shrink-0 border-b border-[var(--color-border)] bg-[var(--color-bg)] pl-6 pr-2">
           <div className="flex items-center gap-4 h-11">
-            {/* Left: status + model + tabs */}
-            <div className="flex items-center gap-3">
-              <span className="text-[11px] text-[var(--color-text-muted)]">Status</span>
-              <StatusBadge status={agent.status} />
-              {agent.taskStatus && (
-                <>
-                  <span className="text-[11px] text-[var(--color-text-muted)]">Task</span>
-                  <StatusBadge status={agent.taskStatus} size="sm" />
-                </>
-              )}
-              <Badge variant="outline" className="text-xs font-mono">
-                {agent.model}
-              </Badge>
-              {agent.lifecycle && (
-                <Badge variant="secondary" className="text-xs">
-                  {agent.lifecycle}
+            {/* Left: back button on settings view, otherwise status + model */}
+            {view === "settings" ? (
+              <Button variant="ghost" size="sm" onClick={() => setViewAndUrl("chat")}>
+                <ArrowLeft className="size-3" data-icon="inline-start" />
+                Back to chat
+              </Button>
+            ) : (
+              <div className="flex items-center gap-3">
+                <span className="text-[11px] text-[var(--color-text-muted)]">Status</span>
+                <StatusBadge status={agent.status} />
+                {agent.taskStatus && (
+                  <>
+                    <span className="text-[11px] text-[var(--color-text-muted)]">Task</span>
+                    <StatusBadge status={agent.taskStatus} size="sm" />
+                  </>
+                )}
+                <Badge variant="outline" className="text-xs font-mono">
+                  {agent.model}
                 </Badge>
-              )}
-            </div>
-
-            <div className="h-4 w-px bg-[var(--color-border)]" />
-
-            <TabsList>
-              <TabsTrigger value="chat">Chat</TabsTrigger>
-              <TabsTrigger value="info">Settings</TabsTrigger>
-            </TabsList>
+                {agent.lifecycle && (
+                  <Badge variant="secondary" className="text-xs">
+                    {agent.lifecycle}
+                  </Badge>
+                )}
+              </div>
+            )}
 
             {/* Right: costs + actions */}
             <div className="ml-auto flex items-center gap-3">
@@ -393,73 +389,104 @@ export default function AgentDetailPage() {
                     </Button>
                   }
                 />
+                <Tooltip
+                  content={view === "settings" ? "Back to chat" : "Settings"}
+                  side="bottom"
+                >
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setViewAndUrl(view === "settings" ? "chat" : "settings")}
+                    aria-label={view === "settings" ? "Back to chat" : "Settings"}
+                    className="!px-0 w-7 !bg-white !text-[var(--color-bg)] hover:!bg-white/90 border-white/20"
+                  >
+                    <AnimatePresence mode="wait" initial={false}>
+                      <motion.span
+                        key={view}
+                        className="inline-flex"
+                        initial={{ opacity: 0, rotate: -90, scale: 0.7 }}
+                        animate={{ opacity: 1, rotate: 0, scale: 1 }}
+                        exit={{ opacity: 0, rotate: 90, scale: 0.7 }}
+                        transition={{ duration: 0.18, ease: "easeOut" }}
+                      >
+                        {view === "settings" ? (
+                          <MessageCircle className="size-4" />
+                        ) : (
+                          <SettingsIcon className="size-4" />
+                        )}
+                      </motion.span>
+                    </AnimatePresence>
+                  </Button>
+                </Tooltip>
               </div>
             </div>
           </div>
         </div>
 
-        <TabsContent value="chat" className="flex-1 overflow-hidden flex">
-          <AgentChat
-            agentName={agent.name}
-            agentNamespace={agentNs}
-            agentStatus={agent.status}
-            agentLifecycle={agent.lifecycle}
-            agentContextWindow={agent.modelContextWindow}
-            events={events}
-            taskStatus={agent.taskStatus}
-            initialPending={agent.taskStatus === "Complete" || agent.taskStatus === "Error" ? undefined : initialPending}
-            hasMoreEvents={hasMoreEvents}
-            loadingOlder={loadingOlder}
-            onLoadOlder={loadOlderEvents}
-            scrollContainerRef={scrollContainerRef}
-            scrollSnapshotRef={scrollSnapshotRef}
-            highlightTaskFrom={taskFrom}
-            highlightTaskTo={taskTo}
-            hasNewerEvents={hasNewerEvents}
-            loadingNewer={loadingNewer}
-            onLoadNewer={loadNewerEvents}
-          />
-          <SubAgentPanel agentName={agent.name} events={events} namespace={agentNs} />
-        </TabsContent>
-
-        <TabsContent value="info" className="flex-1 overflow-y-auto p-6">
-          <div className="mx-auto max-w-4xl space-y-6">
-            {/* Status + metrics */}
-            <motion.div
-              className="flex justify-center gap-3"
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.3, ease: "easeOut" }}
-            >
-              <StatusStrip status={agent.status} taskStatus={agent.taskStatus} />
-              <MetricsRow
-                totalCostUSD={agent.totalCostUSD}
-                lastTaskCostUSD={agent.lastTaskCostUSD}
-                totalTokens={agent.totalTokens}
-              />
-            </motion.div>
-
-            {/* Settings */}
-            <SettingsCard agent={agent} agentNs={agentNs} onSaved={(updated) => { if (updated) setAgent(updated); fetchAgent(); }} />
-
-            {/* Topology */}
-            <AgentTopology agentName={agent.name} agentNs={agentNs} />
-
-            {/* Agent info */}
-            <motion.div
-              className="rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] p-5 space-y-3 transition-colors duration-150 hover:border-[var(--color-border-hover)] hover:bg-[var(--color-surface-hover)]"
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.3, ease: "easeOut", delay: 0.1 }}
-            >
-              <h3 className="text-[11px] uppercase tracking-wider font-semibold text-[var(--color-text-muted)]">Agent Info</h3>
-              <InfoRow label="Name" value={agent.name} />
-              <InfoRow label="Namespace" value={agent.namespace} />
-              <InfoRow label="Created" value={new Date(agent.createdAt).toLocaleString()} />
-            </motion.div>
+        {view === "chat" ? (
+          <div className="flex-1 overflow-hidden flex">
+            <AgentChat
+              agentName={agent.name}
+              agentNamespace={agentNs}
+              agentStatus={agent.status}
+              agentLifecycle={agent.lifecycle}
+              agentContextWindow={agent.modelContextWindow}
+              events={events}
+              taskStatus={agent.taskStatus}
+              initialPending={agent.taskStatus === "Complete" || agent.taskStatus === "Error" ? undefined : initialPending}
+              hasMoreEvents={hasMoreEvents}
+              loadingOlder={loadingOlder}
+              onLoadOlder={loadOlderEvents}
+              scrollContainerRef={scrollContainerRef}
+              scrollSnapshotRef={scrollSnapshotRef}
+              highlightTaskFrom={taskFrom}
+              highlightTaskTo={taskTo}
+              hasNewerEvents={hasNewerEvents}
+              loadingNewer={loadingNewer}
+              onLoadNewer={loadNewerEvents}
+            />
+            <SubAgentPanel agentName={agent.name} events={events} namespace={agentNs} />
           </div>
-        </TabsContent>
-      </Tabs>
+        ) : (
+          <div className="flex-1 overflow-y-auto p-6">
+            <div className="mx-auto max-w-4xl space-y-6">
+              {/* Status + metrics */}
+              <motion.div
+                className="flex justify-center gap-3"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, ease: "easeOut" }}
+              >
+                <StatusStrip status={agent.status} taskStatus={agent.taskStatus} />
+                <MetricsRow
+                  totalCostUSD={agent.totalCostUSD}
+                  lastTaskCostUSD={agent.lastTaskCostUSD}
+                  totalTokens={agent.totalTokens}
+                />
+              </motion.div>
+
+              {/* Settings */}
+              <SettingsCard agent={agent} agentNs={agentNs} onSaved={(updated) => { if (updated) setAgent(updated); fetchAgent(); }} />
+
+              {/* Topology */}
+              <AgentTopology agentName={agent.name} agentNs={agentNs} />
+
+              {/* Agent info */}
+              <motion.div
+                className="rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] p-5 space-y-3 transition-colors duration-150 hover:border-[var(--color-border-hover)] hover:bg-[var(--color-surface-hover)]"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, ease: "easeOut", delay: 0.1 }}
+              >
+                <h3 className="text-[11px] uppercase tracking-wider font-semibold text-[var(--color-text-muted)]">Agent Info</h3>
+                <InfoRow label="Name" value={agent.name} />
+                <InfoRow label="Namespace" value={agent.namespace} />
+                <InfoRow label="Created" value={new Date(agent.createdAt).toLocaleString()} />
+              </motion.div>
+            </div>
+          </div>
+        )}
+      </div>
     </motion.div>
   );
 }

--- a/komputer-ui/src/app/agents/page.tsx
+++ b/komputer-ui/src/app/agents/page.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { motion } from "framer-motion";
+import { Trash2, X, CheckSquare } from "lucide-react";
 
 import { Button } from "@/components/kit/button";
-import { AgentCards } from "@/components/agents/agent-cards";
+import { AgentCards, agentKey } from "@/components/agents/agent-cards";
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
 import { EmptyState } from "@/components/shared/empty-state";
 import { SkeletonTable } from "@/components/shared/loading-skeleton";
 import { ListFilterBar } from "@/components/shared/list-filter-bar";
 import { useAgents } from "@/hooks/use-agents";
 import { useDelayedLoading } from "@/hooks/use-delayed-loading";
-import { usePageRefresh } from "@/components/layout/app-shell";
+import { usePageRefresh, usePageHeaderSlot } from "@/components/layout/app-shell";
 import { deleteAgent } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -45,6 +47,24 @@ export default function AgentsPage() {
     return result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   }, [agents, statusFilter, search, namespace]);
 
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+
+  const toggleSelect = useCallback((key: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => setSelected(new Set()), []);
+
+  const selectAll = useCallback(() => {
+    setSelected(new Set(filtered.map((a) => agentKey(a))));
+  }, [filtered]);
+
   async function handleDelete(name: string, namespace: string) {
     try {
       await deleteAgent(name, namespace);
@@ -53,6 +73,67 @@ export default function AgentsPage() {
       // Deletion errors are non-critical; next poll will update
     }
   }
+
+  async function handleBulkDelete() {
+    if (selected.size === 0) return;
+    setBulkDeleting(true);
+    try {
+      const targets = filtered.filter((a) => selected.has(agentKey(a)));
+      await Promise.allSettled(targets.map((a) => deleteAgent(a.name, a.namespace)));
+      setSelected(new Set());
+      refresh();
+    } finally {
+      setBulkDeleting(false);
+    }
+  }
+
+  // Inject the bulk-action bar into the global header (left of "+ New Agent").
+  const allSelected = selected.size > 0 && selected.size === filtered.length;
+
+  const headerSlot = useMemo(() => {
+    if (selected.size === 0) return null;
+    return (
+      <motion.div
+        initial={{ opacity: 0, x: 8 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.12 }}
+        className="flex items-center gap-1.5 pl-2.5 pr-1.5 py-1 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)]"
+      >
+        <span className="text-xs text-[var(--color-text-secondary)]">{selected.size} selected</span>
+        <div className="h-4 w-px bg-[var(--color-border)]" />
+        <button
+          type="button"
+          onClick={selectAll}
+          disabled={allSelected}
+          className="flex items-center gap-1 h-6 px-2 rounded text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-surface-hover)] transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-default"
+        >
+          <CheckSquare className="size-3" />
+          Select all
+        </button>
+        <button
+          type="button"
+          onClick={clearSelection}
+          className="flex items-center gap-1 h-6 px-2 rounded text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-surface-hover)] transition-colors cursor-pointer"
+        >
+          <X className="size-3" />
+          Clear
+        </button>
+        <ConfirmDialog
+          title={`Delete ${selected.size} agent${selected.size === 1 ? "" : "s"}?`}
+          description="This will permanently delete the selected agents and their workspaces."
+          onConfirm={handleBulkDelete}
+          trigger={
+            <Button variant="destructive" size="sm" disabled={bulkDeleting} className="!h-6 !px-2.5 text-xs">
+              <Trash2 className="size-3" data-icon="inline-start" />
+              {bulkDeleting ? "Deleting..." : `Delete ${selected.size}`}
+            </Button>
+          }
+        />
+      </motion.div>
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected.size, bulkDeleting, clearSelection, selectAll, allSelected]);
+  usePageHeaderSlot(headerSlot);
 
   return (
     <div className="flex h-full flex-col">
@@ -90,6 +171,7 @@ export default function AgentsPage() {
           </div>
         </ListFilterBar>
 
+
         {/* Content */}
         {showLoading ? (
           <SkeletonTable />
@@ -108,7 +190,12 @@ export default function AgentsPage() {
             description="Try adjusting your search or filter criteria."
           />
         ) : (
-          <AgentCards agents={filtered} onDelete={handleDelete} />
+          <AgentCards
+            agents={filtered}
+            onDelete={handleDelete}
+            selected={selected}
+            onToggleSelect={toggleSelect}
+          />
         )}
       </motion.div>
     </div>

--- a/komputer-ui/src/app/globals.css
+++ b/komputer-ui/src/app/globals.css
@@ -212,3 +212,29 @@
     font-weight: 600;
   }
 }
+
+@keyframes agent-check-pop {
+  0%   { transform: scale(0.2); opacity: 0; }
+  50%  { transform: scale(1.2); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.agent-select-border-in {
+  stroke-dasharray: 100;
+  stroke-dashoffset: 100;
+  animation: agent-border-fill-in 320ms ease-out forwards;
+}
+
+.agent-select-border-out {
+  stroke-dasharray: 100;
+  stroke-dashoffset: 0;
+  animation: agent-border-fill-out 260ms ease-in forwards;
+}
+
+@keyframes agent-border-fill-in {
+  to { stroke-dashoffset: 0; }
+}
+
+@keyframes agent-border-fill-out {
+  to { stroke-dashoffset: 100; }
+}

--- a/komputer-ui/src/components/agents/agent-cards.tsx
+++ b/komputer-ui/src/components/agents/agent-cards.tsx
@@ -1,16 +1,21 @@
 "use client";
 
 import Link from "next/link";
-import { Bot, Trash2, Zap, Moon, Skull, Clock, CheckCircle2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Bot, Trash2, Zap, Moon, Skull, Clock, CheckCircle2, Check } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Button } from "@/components/kit/button";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
 import { formatCost, formatRelativeTime } from "@/lib/utils";
 import type { AgentResponse } from "@/lib/types";
 
+export const agentKey = (a: { name: string; namespace: string }) => `${a.namespace}/${a.name}`;
+
 type AgentCardsProps = {
   agents: AgentResponse[];
   onDelete: (name: string, namespace: string) => void;
+  selected?: Set<string>;
+  onToggleSelect?: (key: string) => void;
 };
 
 const statusConfig: Record<string, { color: string; icon: typeof Bot; pulse?: boolean }> = {
@@ -23,7 +28,8 @@ const statusConfig: Record<string, { color: string; icon: typeof Bot; pulse?: bo
 
 const defaultStatus = { color: "#8899A6", icon: Bot };
 
-export function AgentCards({ agents, onDelete }: AgentCardsProps) {
+export function AgentCards({ agents, onDelete, selected, onToggleSelect }: AgentCardsProps) {
+  const selectionMode = !!selected && selected.size > 0;
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-2.5">
       <AnimatePresence>
@@ -31,6 +37,20 @@ export function AgentCards({ agents, onDelete }: AgentCardsProps) {
           const cfg = statusConfig[agent.status] ?? defaultStatus;
           const StatusIcon = cfg.icon;
           const isActive = agent.taskStatus === "InProgress";
+          const key = agentKey(agent);
+          const isSelected = !!selected?.has(key);
+
+          const handleCardClick = (e: React.MouseEvent) => {
+            if (selectionMode && onToggleSelect) {
+              e.preventDefault();
+              onToggleSelect(key);
+            }
+          };
+          const handleCheckboxClick = (e: React.MouseEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onToggleSelect?.(key);
+          };
 
           return (
             <motion.div
@@ -40,18 +60,52 @@ export function AgentCards({ agents, onDelete }: AgentCardsProps) {
               exit={{ opacity: 0, scale: 0.97 }}
               transition={{ duration: 0.25, delay: i * 0.04 }}
             >
-              <Link href={`/agents/${agent.name}?namespace=${agent.namespace}`} className="block group">
-                <div className="relative overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] transition-all duration-200 group-hover:border-[var(--color-border-hover)] group-hover:shadow-[0_0_20px_rgba(63,133,217,0.06),0_0_40px_rgba(139,92,246,0.04)]">
+              <Link href={`/agents/${agent.name}?namespace=${agent.namespace}`} className="block group" onClick={handleCardClick}>
+                <div
+                  className={`relative rounded-[var(--radius-md)] border bg-[var(--color-surface)] ${
+                    isSelected
+                      ? "border-[var(--color-border)]"
+                      : "border-[var(--color-border)] transition-[border-color,box-shadow] duration-150 group-hover:border-[var(--color-border-hover)] group-hover:shadow-[0_0_20px_rgba(63,133,217,0.06),0_0_40px_rgba(139,92,246,0.04)]"
+                  }`}
+                  style={isSelected ? { boxShadow: "0 0 20px rgba(63,133,217,0.15)" } : undefined}
+                >
+                  <SelectionBorder active={isSelected} />
+
 
                   <div className="p-3 flex flex-col h-full">
-                    {/* Top row: icon + name + delete + dot */}
+                    {/* Top row: icon/checkbox + name + delete + dot */}
                     <div className="flex items-center gap-2">
-                      <div
-                        className="flex items-center justify-center w-7 h-7 rounded-md shrink-0"
-                        style={{ backgroundColor: `${cfg.color}15` }}
+                      <button
+                        type="button"
+                        onClick={handleCheckboxClick}
+                        className={`relative flex items-center justify-center w-7 h-7 rounded-md shrink-0 cursor-pointer ${
+                          isSelected
+                            ? "bg-[var(--color-brand-blue)]"
+                            : `${selectionMode ? "" : "group-hover:ring-1 group-hover:ring-[var(--color-border-hover)]"}`
+                        }`}
+                        style={!isSelected ? { backgroundColor: `${cfg.color}15` } : undefined}
+                        aria-label={isSelected ? "Deselect agent" : "Select agent"}
                       >
-                        <StatusIcon className="w-3.5 h-3.5" style={{ color: cfg.color }} />
-                      </div>
+                        {isSelected ? (
+                          <Check
+                            className="w-3.5 h-3.5 text-white"
+                            strokeWidth={3}
+                            style={{ animation: "agent-check-pop 180ms ease-out" }}
+                          />
+                        ) : (
+                          <span className="relative inline-flex">
+                            <StatusIcon
+                              className={`w-3.5 h-3.5 ${onToggleSelect ? "group-hover:opacity-0" : ""}`}
+                              style={{ color: cfg.color }}
+                            />
+                            {onToggleSelect && (
+                              <span className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100">
+                                <span className="w-3.5 h-3.5 rounded border border-[var(--color-text-secondary)]" />
+                              </span>
+                            )}
+                          </span>
+                        )}
+                      </button>
                       <span className="text-[13px] font-semibold text-[var(--color-text)] truncate leading-tight flex-1 min-w-0">
                         {agent.name}
                       </span>
@@ -116,5 +170,77 @@ export function AgentCards({ agents, onDelete }: AgentCardsProps) {
         })}
       </AnimatePresence>
     </div>
+  );
+}
+
+// Animated selection border. Renders an SVG <rect> matching the parent's
+// pixel size so rounded corners stay perfectly circular (no aspect-ratio
+// stretching). Animates the stroke from 0% → 100% on select and 100% → 0%
+// on deselect. Stays mounted briefly during the deselect to play the exit.
+function SelectionBorder({ active }: { active: boolean }) {
+  const [show, setShow] = useState(active);
+  const [drawing, setDrawing] = useState<"in" | "out">(active ? "in" : "out");
+  const [size, setSize] = useState<{ w: number; h: number } | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Measure the parent on mount and on resize.
+  useEffect(() => {
+    const el = wrapperRef.current?.parentElement;
+    if (!el) return;
+    const update = () => setSize({ w: el.clientWidth, h: el.clientHeight });
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (active) {
+      setShow(true);
+      setDrawing("in");
+    } else if (show) {
+      setDrawing("out");
+      const t = setTimeout(() => setShow(false), 280);
+      return () => clearTimeout(t);
+    }
+  }, [active, show]);
+
+  if (!show || !size) {
+    // Keep ref mounted so we can measure the parent.
+    return <div ref={wrapperRef} className="hidden" aria-hidden />;
+  }
+
+  // Draw rect at +1px outside so it overlaps the existing 1px border cleanly.
+  const w = size.w + 2;
+  const h = size.h + 2;
+  const r = 11;
+
+  return (
+    <>
+      <div ref={wrapperRef} className="hidden" aria-hidden />
+      <svg
+        className="pointer-events-none absolute"
+        style={{ left: -1, top: -1, width: w, height: h }}
+        width={w}
+        height={h}
+        viewBox={`0 0 ${w} ${h}`}
+      >
+        <rect
+          key={drawing}
+          className={drawing === "in" ? "agent-select-border-in" : "agent-select-border-out"}
+          x={1.5}
+          y={1.5}
+          width={w - 3}
+          height={h - 3}
+          rx={r}
+          ry={r}
+          fill="none"
+          stroke="var(--color-brand-blue)"
+          strokeWidth={3}
+          strokeLinejoin="round"
+          pathLength={100}
+        />
+      </svg>
+    </>
   );
 }

--- a/komputer-ui/src/components/layout/app-shell.tsx
+++ b/komputer-ui/src/components/layout/app-shell.tsx
@@ -36,6 +36,21 @@ export function usePageRefresh(refreshFn: () => void) {
   }, [ctx]);
 }
 
+// --- Header slot context — lets a page inject custom content (e.g. bulk actions)
+// to the left of the page-specific create button.
+type HeaderSlotContextValue = {
+  setSlot: (node: React.ReactNode | null) => void;
+};
+const HeaderSlotContext = createContext<HeaderSlotContextValue | null>(null);
+
+export function usePageHeaderSlot(node: React.ReactNode | null) {
+  const ctx = useContext(HeaderSlotContext);
+  useEffect(() => {
+    ctx?.setSlot(node);
+    return () => ctx?.setSlot(null);
+  }, [ctx, node]);
+}
+
 const pageTitles: Record<string, string> = {
   "/": "Dashboard",
   "/agents": "Agents",
@@ -116,6 +131,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const refreshCtx = useMemo<RefreshContextValue>(() => ({
     register: (fn) => setRefreshFn(() => fn),
     unregister: () => setRefreshFn(null),
+  }), []);
+
+  const [headerSlot, setHeaderSlot] = useState<React.ReactNode | null>(null);
+  const headerSlotCtx = useMemo<HeaderSlotContextValue>(() => ({
+    setSlot: (node) => setHeaderSlot(node),
   }), []);
 
   const handleRefresh = useCallback(() => {
@@ -239,6 +259,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               </>
             )}
 
+            {/* Page-injected header content (e.g. bulk actions) */}
+            {headerSlot}
+
             {/* Page-specific create button */}
             {isSchedulesPage ? (
               <HeaderAction label="New Schedule" onClick={() => setCreateScheduleOpen(true)} />
@@ -268,7 +291,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         </header>
         <main className="flex-1 overflow-y-auto">
           <RefreshContext.Provider value={refreshCtx}>
-            {children}
+            <HeaderSlotContext.Provider value={headerSlotCtx}>
+              {children}
+            </HeaderSlotContext.Provider>
           </RefreshContext.Provider>
         </main>
       </div>


### PR DESCRIPTION
## Summary
- **Agent details page**: removed Chat/Settings tabs; settings is now a cogwheel icon button next to Sleep/Delete with an animated icon swap + a "Back to chat" button on the left when in settings mode.
- **Agents page bulk-select**: hover-reveal checkbox on each card, animated brand-blue draw-in/draw-out border on selection, and a header pill ("N selected · Select all · Clear · Delete N") in the global header (left of "+ New Agent").
- New `usePageHeaderSlot` hook lets any page inject content into the global header next to the create button.

## Test plan
- [ ] On `/agents/<name>`: cogwheel toggles between Chat and Settings views; Back button returns to chat; tooltip visible (not clipped); icon swap animates.
- [ ] On `/agents`: hover a card → checkbox appears; click → selected with animated border, no navigation; click again → border draws out.
- [ ] Header pill appears with selection; Select all selects every filtered agent; Clear clears; Delete N opens confirm dialog and bulk-deletes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
