### PR TITLE
feat(monitoring): Prometheus metrics, ServiceMonitors, Grafana dashboard, local stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ Full SDK reference in [komputer-sdk/](komputer-sdk/).
 3. [Integration Guide](docs/integration-guide.md) — How to connect external systems via HTTP API and WebSocket events
 4. [Custom Agent Images](docs/custom-agent-image.md) — Build custom agent images with your own packages and tools
 5. [Local Development](docs/local-development.md) — Build and run from source on a local cluster
-6. [Examples](examples/) — 10 end-to-end examples: hello world, secrets, managers, schedules, CI/CD, Slack, and more
-7. [Architecture](#architecture) — System diagram and component interactions
-8. Komputer Components
+6. [Monitoring & Metrics](docs/monitoring.md) — Prometheus endpoints, ServiceMonitor setup, agent remote-write, sample Grafana dashboard
+7. [Examples](examples/) — 10 end-to-end examples: hello world, secrets, managers, schedules, CI/CD, Slack, and more
+8. [Architecture](#architecture) — System diagram and component interactions
+9. Komputer Components
    1. [komputer-api](komputer-api/README.md) — REST & WebSocket API reference, Swagger UI, configuration
    2. [komputer-operator](komputer-operator/README.md) — CRD definitions, reconciliation logic, operator development guide
    3. [komputer-agent](komputer-agent/README.md) — Agent runtime, Claude SDK integration, manager tools, event format

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -4,12 +4,12 @@ komputer-ai exposes Prometheus metrics from every component, plus a sample Grafa
 
 ## Components and endpoints
 
-| Component | Endpoint | Always served? | What's exposed |
-|---|---|---|---|
-| API | `:8080/api/metrics` | yes | HTTP request rate/latency, WebSocket connections, Redis stream throughput |
-| API | `:8080/agent/metrics` | yes | Per-task cost, tokens, duration; tool invocations and durations; agent action counts; agents-by-phase, tasks-in-progress, schedules-active gauges (queried from K8s at scrape time) |
-| Operator | `:8080/metrics` | only when bind address set (Helm value `metrics.operator.bindAddress`, default `:8080`) | Built-in controller-runtime metrics + `komputer_operator_template_cap_reached_total` |
-| Agent | `:8000/metrics` | yes (FastAPI server) | Steering events, MCP connector status, subagent wait time |
+| Component | Endpoint | What's exposed |
+|---|---|---|
+| API | `:8080/api/metrics` | HTTP request rate/latency, WebSocket connections, Redis stream throughput |
+| API | `:8080/agent/metrics` | Per-task cost, tokens, duration; tool invocations and durations; agent action counts; agents-by-phase, tasks-in-progress, schedules-active gauges (queried from K8s at scrape time) |
+| Operator | `:8082/metrics` | Built-in controller-runtime metrics + `komputer_operator_template_cap_reached_total` |
+| Agent | `:8000/metrics` | Steering events, MCP connector status, subagent wait time |
 
 ## Enabling Prometheus scraping
 
@@ -66,15 +66,18 @@ metrics:
     remoteWrite:
       enabled: true
       url: http://prometheus.monitoring.svc.cluster.local:9090/api/v1/write
-      # Optional bearer token (from a K8s Secret with key 'KOMPUTER_METRICS_REMOTE_WRITE_TOKEN'):
+      intervalSeconds: 15
+      # Optional bearer token (from a K8s Secret with key 'token'):
       bearerTokenSecret: prometheus-remote-write-token
 ```
 
-The agent flushes every 15 seconds. Failures are logged but never crash the agent.
+The chart injects `KOMPUTER_METRICS_REMOTE_WRITE_URL`, `KOMPUTER_METRICS_REMOTE_WRITE_INTERVAL`, optionally `KOMPUTER_METRICS_REMOTE_WRITE_TOKEN`, and (when `metrics.perAgentLabels=true`) `KOMPUTER_METRICS_PER_AGENT=true` into the default `KomputerAgentClusterTemplate`, so every agent pod inherits them automatically.
+
+Failures during flush are logged but never crash the agent.
 
 Your remote-write target must have receiver enabled. For Prometheus: `--web.enable-remote-write-receiver`. For Mimir/Cortex/Thanos: native support.
 
-> **Note:** the env vars `KOMPUTER_METRICS_REMOTE_WRITE_URL` and `KOMPUTER_METRICS_PER_AGENT` are not yet automatically injected from Helm values into agent pods. To enable today, set them on `KomputerAgentClusterTemplate.spec.podSpec.containers[0].env` directly.
+For local kind dev, the sample `KomputerAgentClusterTemplate` at `komputer-operator/config/samples/komputer_v1alpha1_komputeragentclustertemplate.yaml` already wires the agent to the local Prometheus from `monitoring/docker-compose.yml`. See [local-development.md](local-development.md) and [monitoring/README.md](../monitoring/README.md).
 
 ## Free metrics from kube-state-metrics
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,142 @@
+# Monitoring
+
+komputer-ai exposes Prometheus metrics from every component, plus a sample Grafana dashboard.
+
+## Components and endpoints
+
+| Component | Endpoint | Always served? | What's exposed |
+|---|---|---|---|
+| API | `:8080/api/metrics` | yes | HTTP request rate/latency, WebSocket connections, Redis stream throughput |
+| API | `:8080/agent/metrics` | yes | Per-task cost, tokens, duration; tool invocations and durations; agent action counts; agents-by-phase, tasks-in-progress, schedules-active gauges (queried from K8s at scrape time) |
+| Operator | `:8080/metrics` | only when bind address set (Helm value `metrics.operator.bindAddress`, default `:8080`) | Built-in controller-runtime metrics + `komputer_operator_template_cap_reached_total` |
+| Agent | `:8000/metrics` | yes (FastAPI server) | Steering events, MCP connector status, subagent wait time |
+
+## Enabling Prometheus scraping
+
+The Helm chart includes ServiceMonitor templates compatible with [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack). Enable each independently:
+
+```yaml
+metrics:
+  api:
+    serviceMonitor:
+      enabled: true
+      interval: 30s
+  agentMetrics:
+    serviceMonitor:
+      enabled: true     # /agent/metrics endpoint (separate from /api/metrics)
+      interval: 30s
+  operator:
+    serviceMonitor:
+      enabled: true
+      interval: 30s
+```
+
+Why two ServiceMonitors for the API? `/api/metrics` carries operational metrics (latency, errors). `/agent/metrics` carries business metrics (cost, tokens). You may want different retention or scrape intervals — splitting them keeps that flexible.
+
+There is no ServiceMonitor for agents by default. Agent pods come and go (sleep cycles), so traditional pull-based scraping misses ephemeral activity. Instead, enable remote-write (below).
+
+## Per-agent labels — cardinality trade-off
+
+By default, the `agent_name` label is **present but empty** on per-agent metrics. This keeps dashboards schema-stable — queries like `sum by (agent_name) (...)` work whether or not the feature is enabled, they just resolve to a single bucket when off.
+
+To get real per-agent breakdown:
+
+```yaml
+metrics:
+  perAgentLabels: true
+```
+
+**Cost:** every per-agent metric series multiplies by the number of agents you create. For 100 active agents, the `komputer_agent_tasks_total` series count goes from ~12 (3 outcomes × 4 models) to ~1200. Prometheus handles this fine until you hit hundreds of thousands of series.
+
+**Recommendation:** keep this off for production, enable in pre-prod or for one-off debugging.
+
+## Agent remote-write
+
+Three metrics live only in the agent process — they describe activity that doesn't appear in the Redis event stream:
+
+- `komputer_agent_steering_total` — count of follow-up messages mid-task
+- `komputer_agent_mcp_connector_status` — health of each MCP connector (Slack, GitHub, etc.)
+- `komputer_agent_subagent_wait_seconds` — wall-clock time spent in `wait_for_agents.py`
+
+When agents sleep (the common case), their `/metrics` endpoint disappears before Prometheus's next scrape. To capture these reliably, configure the agent to push them via Prometheus remote-write:
+
+```yaml
+metrics:
+  agent:
+    remoteWrite:
+      enabled: true
+      url: http://prometheus.monitoring.svc.cluster.local:9090/api/v1/write
+      # Optional bearer token (from a K8s Secret with key 'KOMPUTER_METRICS_REMOTE_WRITE_TOKEN'):
+      bearerTokenSecret: prometheus-remote-write-token
+```
+
+The agent flushes every 15 seconds. Failures are logged but never crash the agent.
+
+Your remote-write target must have receiver enabled. For Prometheus: `--web.enable-remote-write-receiver`. For Mimir/Cortex/Thanos: native support.
+
+> **Note:** the env vars `KOMPUTER_METRICS_REMOTE_WRITE_URL` and `KOMPUTER_METRICS_PER_AGENT` are not yet automatically injected from Helm values into agent pods. To enable today, set them on `KomputerAgentClusterTemplate.spec.podSpec.containers[0].env` directly.
+
+## Free metrics from kube-state-metrics
+
+If you're running `kube-prometheus-stack`, you already have:
+
+- `kube_pod_status_phase{namespace,pod}` — pod lifecycle (filter by `pod=~"<agent>-pod"`)
+- `container_cpu_usage_seconds_total{pod=~"...pod$"}` — per-agent CPU
+- `container_memory_working_set_bytes{pod=~"...pod$"}` — per-agent memory
+- `kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace}` — workspace storage
+
+We don't duplicate these in komputer-ai's metrics. Use them for resource-utilization views in your dashboards.
+
+## Sample dashboard
+
+Bundled in `helm/komputer-ai/dashboards/komputer-overview.json`. Loaded automatically into Grafana when you install the chart with any ServiceMonitor enabled (the dashboard ConfigMap has `grafana_dashboard: "1"` for sidecar pickup).
+
+## Local development
+
+For testing without a cluster:
+
+```bash
+cd monitoring && docker compose up -d
+# Prometheus: http://localhost:9090
+# Grafana: http://localhost:3000
+```
+
+See `monitoring/README.md` for full instructions including how to test agent remote-write locally.
+
+## Metric reference
+
+### API plumbing (`/api/metrics`)
+
+- `komputer_api_http_requests_total{method,path,status}` (counter)
+- `komputer_api_http_request_duration_seconds{method,path}` (histogram)
+- `komputer_api_ws_connections_active{mode}` (gauge — `mode=broadcast|group`)
+- `komputer_api_ws_dispatch_total{mode,result}` (counter — `result=delivered|claimed_by_other|write_failed`)
+- `komputer_api_redis_xread_messages_total` (counter)
+- `komputer_api_build_info{version,commit}` (gauge — always 1)
+
+### Agent business (`/agent/metrics`)
+
+- `komputer_agent_tasks_total{namespace,model,outcome,agent_name}` (counter — `outcome=started|completed|cancelled|errored`)
+- `komputer_agent_task_duration_seconds{namespace,model,agent_name}` (histogram)
+- `komputer_agent_task_cost_usd_total{namespace,model,agent_name}` (counter)
+- `komputer_agent_task_tokens_total{namespace,model,kind,agent_name}` (counter — `kind=input|output|cache_read|cache_creation`)
+- `komputer_agent_tool_invocations_total{namespace,tool,outcome,agent_name}` (counter)
+- `komputer_agent_tool_duration_seconds{namespace,tool,agent_name}` (histogram)
+- `komputer_agent_actions_total{action,result}` (counter — `action=create|delete|cancel|sleep|wake|patch`)
+- `komputer_tasks_inprogress{namespace,model,agent_name}` (gauge — listed from K8s at scrape time)
+- `komputer_schedules_active{namespace}` (gauge — listed from K8s at scrape time)
+- `komputer_agents_active{namespace,phase}` (gauge — listed from K8s at scrape time)
+- `komputer_agent_build_info{version,commit}` (gauge — always 1)
+
+### Operator (`/metrics`)
+
+- `controller_runtime_reconcile_total{controller,result}` (counter)
+- `controller_runtime_reconcile_time_seconds{controller}` (histogram)
+- `controller_runtime_active_workers{controller}` (gauge)
+- `komputer_operator_template_cap_reached_total{namespace,template}` (counter)
+
+### Agent push (`/metrics` on agent pod, plus remote-write)
+
+- `komputer_agent_steering_total{agent_name}` (counter)
+- `komputer_agent_mcp_connector_status{agent_name,connector,status}` (gauge — 1 healthy, 0 unhealthy)
+- `komputer_agent_subagent_wait_seconds{agent_name}` (histogram)

--- a/helm/komputer-ai/dashboards/komputer-overview.json
+++ b/helm/komputer-ai/dashboards/komputer-overview.json
@@ -1,11 +1,580 @@
 {
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Komputer.AI platform overview — agent activity, cost, tool usage, API health, operator state, and connector health. Covers all custom metrics emitted by api, agent, and operator.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 1},
+      "id": 1,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum (komputer_agents_active{namespace=~\"$namespace\"})", "legendFormat": "agents", "refId": "A"}],
+      "title": "Total Agents",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 5}, {"color": "red", "value": 20}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 1},
+      "id": 2,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum (komputer_tasks_inprogress{namespace=~\"$namespace\"})", "legendFormat": "tasks", "refId": "A"}],
+      "title": "Tasks In Progress",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 1},
+      "id": 3,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum (komputer_schedules_active{namespace=~\"$namespace\"})", "legendFormat": "schedules", "refId": "A"}],
+      "title": "Active Schedules",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "currencyUSD"
+        }
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
+      "id": 4,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum (komputer_agent_task_cost_usd_total{namespace=~\"$namespace\"})", "legendFormat": "total spend", "refId": "A"}],
+      "title": "Total Cost (cumulative)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "currencyUSD"
+        }
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
+      "id": 5,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum (rate(komputer_agent_task_cost_usd_total{namespace=~\"$namespace\"}[1m])) * 3600", "legendFormat": "$/hr", "refId": "A"}],
+      "title": "Cost Burn Rate ($/hr)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}, "unit": "short"},
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "Failed"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "Running"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "Sleeping"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "blue"}}]},
+          {"matcher": {"id": "byName", "options": "Pending"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]},
+          {"matcher": {"id": "byName", "options": "Queued"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]}
+        ]
+      },
+      "gridPos": {"h": 5, "w": 24, "x": 0, "y": 5},
+      "id": 6,
+      "options": {
+        "displayLabels": ["name", "value"],
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "values": ["value", "percent"]},
+        "pieType": "donut",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "tooltip": {"mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (phase) (komputer_agents_active{namespace=~\"$namespace\"})", "legendFormat": "{{phase}}", "refId": "A"}],
+      "title": "Agent Phase Distribution",
+      "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 10},
+      "id": 101,
+      "panels": [],
+      "title": "Tasks & Cost",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "stacking": {"group": "A", "mode": "normal"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "$/hr"}, "unit": "currencyUSD"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 11},
+      "id": 7,
+      "options": {"legend": {"calcs": ["sum", "mean"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (model) (rate(komputer_agent_task_cost_usd_total{namespace=~\"$namespace\"}[1m])) * 3600", "legendFormat": "{{model}}", "refId": "A"}],
+      "title": "Cost Burn Rate by Model ($/hr)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "stacking": {"group": "A", "mode": "normal"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "tokens/min"}, "unit": "short"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 11},
+      "id": 8,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (kind) (rate(komputer_agent_task_tokens_total{namespace=~\"$namespace\"}[1m])) * 60", "legendFormat": "{{kind}}", "refId": "A"}],
+      "title": "Token Throughput by Kind (per minute)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "bars", "fillOpacity": 80, "lineWidth": 1, "stacking": {"group": "A", "mode": "normal"}, "spanNulls": false, "axisLabel": "tasks/min"}, "unit": "short"},
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "completed"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "errored"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "cancelled"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+          {"matcher": {"id": "byName", "options": "started"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "blue"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 19},
+      "id": 9,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (outcome) (rate(komputer_agent_tasks_total{namespace=~\"$namespace\"}[2m])) * 60", "legendFormat": "{{outcome}}", "refId": "A"}],
+      "title": "Task Outcomes per Minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "p95 seconds"}, "unit": "s"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 19},
+      "id": 10,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.5, sum by (le, model) (rate(komputer_agent_task_duration_seconds_bucket{namespace=~\"$namespace\"}[10m])))", "legendFormat": "{{model}} p50", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le, model) (rate(komputer_agent_task_duration_seconds_bucket{namespace=~\"$namespace\"}[10m])))", "legendFormat": "{{model}} p95", "refId": "B"}
+      ],
+      "title": "Task Duration p50/p95 by Model",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 27},
+      "id": 102,
+      "panels": [],
+      "title": "Tools",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "calls in 5m"}, "unit": "short"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 28},
+      "id": 11,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "topk(10, sum by (tool) (increase(komputer_agent_tool_invocations_total{namespace=~\"$namespace\"}[5m])))", "legendFormat": "{{tool}}", "refId": "A"}],
+      "title": "Top 10 Tools by Calls (5m window)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "custom": {"drawStyle": "line", "fillOpacity": 30, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "errors/min"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}]}, "unit": "short"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 28},
+      "id": 12,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (tool) (rate(komputer_agent_tool_invocations_total{namespace=~\"$namespace\",outcome=\"error\"}[5m])) * 60", "legendFormat": "{{tool}}", "refId": "A"}],
+      "title": "Tool Errors Rate (per minute)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "p95 seconds"}, "unit": "s"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 36},
+      "id": 13,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le, tool) (rate(komputer_agent_tool_duration_seconds_bucket{namespace=~\"$namespace\"}[10m])))", "legendFormat": "{{tool}}", "refId": "A"}],
+      "title": "Tool Execution Duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 5}]}, "unit": "percentunit"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 36},
+      "id": 14,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10, "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showUnfilled": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (tool) (rate(komputer_agent_tool_invocations_total{namespace=~\"$namespace\",outcome=\"error\"}[5m])) / clamp_min(sum by (tool) (rate(komputer_agent_tool_invocations_total{namespace=~\"$namespace\"}[5m])), 0.001)", "legendFormat": "{{tool}}", "refId": "A"}],
+      "title": "Tool Error Ratio (errors / total)",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 44},
+      "id": 103,
+      "panels": [],
+      "title": "API Health",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "p95 ms"}, "unit": "s"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 45},
+      "id": 15,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le, path) (rate(komputer_api_http_request_duration_seconds_bucket[5m])))", "legendFormat": "{{path}}", "refId": "A"}],
+      "title": "API Request Latency p95 by Path",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "stacking": {"group": "A", "mode": "normal"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "req/min"}, "unit": "short"},
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": "5\\d\\d"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byRegexp", "options": "4\\d\\d"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]},
+          {"matcher": {"id": "byRegexp", "options": "2\\d\\d"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 45},
+      "id": 16,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (status) (rate(komputer_api_http_requests_total[1m])) * 60", "legendFormat": "HTTP {{status}}", "refId": "A"}],
+      "title": "API Request Rate by Status (per minute)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 30, "lineWidth": 2, "stacking": {"group": "A", "mode": "normal"}, "spanNulls": false, "showPoints": "auto", "lineInterpolation": "stepAfter", "axisLabel": "connections"}, "unit": "short"}
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 53},
+      "id": 17,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (mode) (komputer_api_ws_connections_active)", "legendFormat": "{{mode}}", "refId": "A"}],
+      "title": "WebSocket Connections (broadcast vs group)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "events/min"}, "unit": "short"},
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": ".*write_failed.*"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byRegexp", "options": ".*delivered.*"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byRegexp", "options": ".*claimed_by_other.*"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "blue"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 53},
+      "id": 18,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (mode, result) (rate(komputer_api_ws_dispatch_total[1m])) * 60", "legendFormat": "{{mode}} / {{result}}", "refId": "A"}],
+      "title": "WebSocket Dispatch Outcomes (per minute)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "events/min"}, "unit": "short"}
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 53},
+      "id": 19,
+      "options": {"legend": {"calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "rate(komputer_api_redis_xread_messages_total[1m]) * 60", "legendFormat": "events/min", "refId": "A"}],
+      "title": "Redis Stream Throughput (broadcast worker, per minute)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 61},
+      "id": 104,
+      "panels": [],
+      "title": "Operator & Admission",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "custom": {"drawStyle": "bars", "fillOpacity": 80, "lineWidth": 1, "stacking": {"group": "A", "mode": "normal"}, "spanNulls": false, "axisLabel": "denies/min"}, "thresholds": {"mode": "absolute", "steps": [{"color": "orange", "value": null}]}, "unit": "short"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 62},
+      "id": 20,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (template) (rate(komputer_operator_template_cap_reached_total{namespace=~\"$namespace\"}[5m])) * 60", "legendFormat": "{{template}}", "refId": "A"}],
+      "title": "Template Cap Hit Rate (denies/min)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "bars", "fillOpacity": 70, "lineWidth": 1, "stacking": {"group": "A", "mode": "normal"}, "spanNulls": false, "axisLabel": "actions/min"}, "unit": "short"},
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": ".*error.*"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 62},
+      "id": 21,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (action, result) (rate(komputer_agent_actions_total[2m])) * 60", "legendFormat": "{{action}} {{result}}", "refId": "A"}],
+      "title": "Agent Actions Rate (create/delete/cancel/sleep/wake/patch)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "p95 seconds"}, "unit": "s"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 70},
+      "id": 22,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket[5m])))", "legendFormat": "{{controller}}", "refId": "A"}],
+      "title": "Operator Reconcile Duration p95 (built-in)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "reconciles/min"}, "unit": "short"},
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": ".*error.*"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byRegexp", "options": ".*success.*"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 70},
+      "id": 23,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (controller, result) (rate(controller_runtime_reconcile_total[1m])) * 60", "legendFormat": "{{controller}} {{result}}", "refId": "A"}],
+      "title": "Operator Reconcile Rate by Result (built-in)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 78},
+      "id": 105,
+      "panels": [],
+      "title": "Agent-Side Push Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "bars", "fillOpacity": 70, "lineWidth": 1, "stacking": {"group": "A", "mode": "normal"}, "spanNulls": false, "axisLabel": "events/min"}, "unit": "short"}
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 79},
+      "id": 24,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (agent_name) (rate(komputer_agent_steering_total[2m])) * 60", "legendFormat": "{{agent_name}}", "refId": "A"}],
+      "title": "Steering Events / min (by agent)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}, "spanNulls": false, "showPoints": "auto", "axisLabel": "p95 seconds"}, "unit": "s"}
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 79},
+      "id": 25,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le, agent_name) (rate(komputer_agent_subagent_wait_seconds_bucket[10m])))", "legendFormat": "{{agent_name}}", "refId": "A"}],
+      "title": "Subagent Wait Time p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {"align": "auto", "cellOptions": {"type": "color-background"}, "inspect": false},
+          "mappings": [{"options": {"0": {"color": "red", "index": 0, "text": "DOWN"}, "1": {"color": "green", "index": 1, "text": "UP"}}, "type": "value"}],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 79},
+      "id": 26,
+      "options": {"cellHeight": "sm", "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false}, "showHeader": true},
+      "pluginVersion": "11.4.0",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "komputer_agent_mcp_connector_status", "format": "table", "instant": true, "refId": "A"}],
+      "title": "MCP Connector Health (per agent)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {"Time": true, "__name__": true, "job": true, "instance": true, "status": true},
+            "indexByName": {},
+            "renameByName": {"agent_name": "Agent", "connector": "Connector", "Value": "Status"}
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["komputer-ai"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {"selected": true, "text": ["All"], "value": ["$__all"]},
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "definition": "label_values(komputer_agents_active, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {"qryType": 1, "query": "label_values(komputer_agents_active, namespace)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {"selected": true, "text": ["All"], "value": ["$__all"]},
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "definition": "label_values(komputer_agent_tasks_total{agent_name!=\"\"}, agent_name)",
+        "description": "Only useful when KOMPUTER_METRICS_PER_AGENT=true. Otherwise all metrics have agent_name=\"\".",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Agent (requires perAgentLabels)",
+        "multi": true,
+        "name": "agent_name",
+        "options": [],
+        "query": {"qryType": 1, "query": "label_values(komputer_agent_tasks_total{agent_name!=\"\"}, agent_name)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
   "title": "Komputer Overview",
   "uid": "komputer-overview",
-  "schemaVersion": 38,
   "version": 1,
-  "panels": [],
-  "time": {"from": "now-1h", "to": "now"},
-  "tags": ["komputer-ai"],
-  "annotations": {"list": []},
-  "templating": {"list": []}
+  "weekStart": ""
 }

--- a/helm/komputer-ai/dashboards/komputer-overview.json
+++ b/helm/komputer-ai/dashboards/komputer-overview.json
@@ -1,0 +1,11 @@
+{
+  "title": "Komputer Overview",
+  "uid": "komputer-overview",
+  "schemaVersion": 38,
+  "version": 1,
+  "panels": [],
+  "time": {"from": "now-1h", "to": "now"},
+  "tags": ["komputer-ai"],
+  "annotations": {"list": []},
+  "templating": {"list": []}
+}

--- a/helm/komputer-ai/templates/dashboards-configmap.yaml
+++ b/helm/komputer-ai/templates/dashboards-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if or .Values.metrics.api.serviceMonitor.enabled .Values.metrics.agentMetrics.serviceMonitor.enabled .Values.metrics.operator.serviceMonitor.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-dashboards
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "komputer.labels" . | nindent 4 }}
+    grafana_dashboard: "1"
+data:
+  komputer-overview.json: |
+{{ .Files.Get "dashboards/komputer-overview.json" | indent 4 }}
+{{- end }}

--- a/helm/komputer-ai/templates/komputer-agent/clustertemplate.yaml
+++ b/helm/komputer-ai/templates/komputer-agent/clustertemplate.yaml
@@ -30,6 +30,25 @@ spec:
             name: {{ .Values.anthropicApiKeySecret.name }}
             key: {{ .Values.anthropicApiKeySecret.key }}
       {{- end }}
+      {{- if .Values.metrics.perAgentLabels }}
+      - name: KOMPUTER_METRICS_PER_AGENT
+        value: "true"
+      {{- end }}
+      {{- if .Values.metrics.agent.remoteWrite.enabled }}
+      - name: KOMPUTER_METRICS_REMOTE_WRITE_URL
+        value: {{ .Values.metrics.agent.remoteWrite.url | quote }}
+      {{- if .Values.metrics.agent.remoteWrite.intervalSeconds }}
+      - name: KOMPUTER_METRICS_REMOTE_WRITE_INTERVAL
+        value: {{ .Values.metrics.agent.remoteWrite.intervalSeconds | quote }}
+      {{- end }}
+      {{- if .Values.metrics.agent.remoteWrite.bearerTokenSecret }}
+      - name: KOMPUTER_METRICS_REMOTE_WRITE_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.metrics.agent.remoteWrite.bearerTokenSecret }}
+            key: token
+      {{- end }}
+      {{- end }}
       resources:
         {{- toYaml .Values.clusterTemplate.resources | nindent 8 }}
   storage:

--- a/helm/komputer-ai/templates/komputer-api/deployment.yaml
+++ b/helm/komputer-ai/templates/komputer-api/deployment.yaml
@@ -37,6 +37,8 @@ spec:
           value: {{ include "komputer.redisAddress" . }}
         - name: REDIS_STREAM_PREFIX
           value: {{ .Values.config.redis.streamPrefix }}
+        - name: KOMPUTER_METRICS_PER_AGENT
+          value: {{ .Values.metrics.perAgentLabels | quote }}
         {{- if .Values.api.oauth.callbackUrl }}
         - name: OAUTH_CALLBACK_URL
           value: {{ .Values.api.oauth.callbackUrl | quote }}

--- a/helm/komputer-ai/templates/komputer-api/servicemonitor.yaml
+++ b/helm/komputer-ai/templates/komputer-api/servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.metrics.api.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "komputer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+    {{- with .Values.metrics.api.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: komputer
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: api
+  endpoints:
+    - port: http
+      path: /api/metrics
+      interval: {{ .Values.metrics.api.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.metrics.agentMetrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-agent-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "komputer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+    {{- with .Values.metrics.agentMetrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: komputer
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: api
+  endpoints:
+    - port: http
+      path: /agent/metrics
+      interval: {{ .Values.metrics.agentMetrics.serviceMonitor.interval }}
+{{- end }}

--- a/helm/komputer-ai/templates/komputer-operator/deployment.yaml
+++ b/helm/komputer-ai/templates/komputer-operator/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         - containerPort: 8081
           name: health
           protocol: TCP
-        - containerPort: 8080
+        - containerPort: 8082
           name: metrics
           protocol: TCP
         livenessProbe:

--- a/helm/komputer-ai/templates/komputer-operator/deployment.yaml
+++ b/helm/komputer-ai/templates/komputer-operator/deployment.yaml
@@ -40,6 +40,8 @@ spec:
         - --leader-elect
         {{- end }}
         - --health-probe-bind-address=:8081
+        - --metrics-bind-address={{ .Values.metrics.operator.bindAddress }}
+        - --metrics-secure=false
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -48,6 +50,9 @@ spec:
         ports:
         - containerPort: 8081
           name: health
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
           protocol: TCP
         livenessProbe:
           httpGet:

--- a/helm/komputer-ai/templates/komputer-operator/service.yaml
+++ b/helm/komputer-ai/templates/komputer-operator/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: ClusterIP
   ports:
     - name: metrics
-      port: 8080
+      port: 8082
       targetPort: metrics
   selector:
     app.kubernetes.io/name: komputer

--- a/helm/komputer-ai/templates/komputer-operator/service.yaml
+++ b/helm/komputer-ai/templates/komputer-operator/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.operator.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-operator-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "komputer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: komputer
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: operator
+{{- end }}

--- a/helm/komputer-ai/templates/komputer-operator/servicemonitor.yaml
+++ b/helm/komputer-ai/templates/komputer-operator/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.metrics.operator.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "komputer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+    {{- with .Values.metrics.operator.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: komputer
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: operator
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.operator.serviceMonitor.interval }}
+{{- end }}

--- a/helm/komputer-ai/values.yaml
+++ b/helm/komputer-ai/values.yaml
@@ -204,18 +204,19 @@ metrics:
       enabled: false
       interval: 30s
       labels: {}
-    # Operator metrics are disabled by default in upstream Kubebuilder; we
-    # bind to :8080 by default here so the SM has something to scrape.
-    bindAddress: ":8080"
+    # Operator metrics bind to :8082 (avoids collision with the API on :8080
+    # when port-forwarding both, and with the operator's own probe on :8081).
+    bindAddress: ":8082"
 
   agent:
-    # NOTE: Setting these does not currently propagate to agent pods automatically.
-    # The operator does not yet read remote-write config from the chart. To enable
-    # remote-write today, set the env vars on KomputerAgentClusterTemplate.spec.podSpec
-    # directly or via a manual env injection.
+    # Push agent-side metrics (steering, mcp_status, subagent_wait) to a
+    # Prometheus remote-write endpoint. When enabled, env vars are injected
+    # into the default KomputerAgentClusterTemplate so every spawned agent
+    # pod inherits them.
     remoteWrite:
       enabled: false
       url: ""  # e.g. http://prometheus.monitoring:9090/api/v1/write
+      intervalSeconds: 15
       bearerTokenSecret: ""  # name of K8s Secret with key 'token'
 
 # -- Default KomputerAgentClusterTemplate settings

--- a/helm/komputer-ai/values.yaml
+++ b/helm/komputer-ai/values.yaml
@@ -176,6 +176,48 @@ config:
 defaultSkills:
   enabled: true
 
+# --- Monitoring & metrics ---
+metrics:
+  # When true, agent_name is exposed as a real label on per-agent metrics.
+  # When false (default), agent_name is present-but-empty so dashboards
+  # stay schema-stable. Trade-off: high cardinality if you have many agents.
+  perAgentLabels: false
+
+  api:
+    serviceMonitor:
+      # Scrape /api/metrics on the API service. Requires kube-prometheus-stack.
+      enabled: false
+      interval: 30s
+      labels: {}  # extra labels for the SM CR (e.g. release: kube-prom)
+
+  agentMetrics:
+    serviceMonitor:
+      # Scrape /agent/metrics on the API service (same pod, separate endpoint).
+      # Splits API plumbing metrics from agent business metrics so they can be
+      # scraped/retained separately if desired.
+      enabled: false
+      interval: 30s
+      labels: {}
+
+  operator:
+    serviceMonitor:
+      enabled: false
+      interval: 30s
+      labels: {}
+    # Operator metrics are disabled by default in upstream Kubebuilder; we
+    # bind to :8080 by default here so the SM has something to scrape.
+    bindAddress: ":8080"
+
+  agent:
+    # NOTE: Setting these does not currently propagate to agent pods automatically.
+    # The operator does not yet read remote-write config from the chart. To enable
+    # remote-write today, set the env vars on KomputerAgentClusterTemplate.spec.podSpec
+    # directly or via a manual env injection.
+    remoteWrite:
+      enabled: false
+      url: ""  # e.g. http://prometheus.monitoring:9090/api/v1/write
+      bearerTokenSecret: ""  # name of K8s Secret with key 'token'
+
 # -- Default KomputerAgentClusterTemplate settings
 clusterTemplate:
   # -- PVC storage size for agent workspaces

--- a/komputer-agent/Dockerfile
+++ b/komputer-agent/Dockerfile
@@ -15,10 +15,12 @@ RUN ARCH=$(dpkg --print-architecture) && \
     tar -xzf - -C /usr/local/bin ./gws && \
     chmod +x /usr/local/bin/gws
 
-# Install Python dependencies
+# Install Python dependencies (libsnappy-dev required for python-snappy)
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt && \
+RUN apt-get update && apt-get install -y --no-install-recommends libsnappy-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install --no-cache-dir -r requirements.txt && \
     pip cache purge 2>/dev/null; rm -rf /root/.cache/pip
 
 COPY . .

--- a/komputer-agent/agent.py
+++ b/komputer-agent/agent.py
@@ -98,6 +98,7 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
     publisher.publish("task_started", {
         "instructions": user_task,
         "resuming_session": session_id is not None,
+        "model": model,
     })
 
     async def post_tool_hook(input, session_id, ctx):
@@ -262,6 +263,7 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
                     "usage": result.usage,
                     "last_usage": last_usage,
                     "context_window": _fetch_context_window(model),
+                    "model": model,
                 })
 
     # Clear the queue reference so server.py won't try to push to a dead queue.

--- a/komputer-agent/agent.py
+++ b/komputer-agent/agent.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 import httpx
+import metrics as agent_metrics
 
 from claude_agent_sdk import (
     AssistantMessage,
@@ -157,6 +158,7 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
                         if token:
                             cfg["headers"] = {"Authorization": f"Bearer {token}"}
                 mcp_servers[name] = cfg
+                agent_metrics.set_mcp_status(name, healthy=True)
         except Exception as e:
             print(f"[komputer] failed to parse KOMPUTER_MCP_SERVERS: {e}")
 

--- a/komputer-agent/main.py
+++ b/komputer-agent/main.py
@@ -9,6 +9,7 @@ import uvicorn
 from agent import run_agent, _write_skills
 from events import EventPublisher
 import config
+import metrics as agent_metrics
 import state
 
 
@@ -72,6 +73,9 @@ def main():
     user_system_prompt = os.getenv("KOMPUTER_SYSTEM_PROMPT", "")
     combined_prompt_parts = [p for p in [internal_system_prompt, user_system_prompt] if p]
     combined_system_prompt = "\n\n".join(combined_prompt_parts) if combined_prompt_parts else None
+
+    # Initialize metrics module (must happen before server starts).
+    agent_metrics.init()
 
     # Initialize runtime config from env vars.
     config.init()

--- a/komputer-agent/metrics.py
+++ b/komputer-agent/metrics.py
@@ -234,4 +234,8 @@ def start_flush_task(loop: Optional[asyncio.AbstractEventLoop] = None):
     if not os.environ.get("KOMPUTER_METRICS_REMOTE_WRITE_URL", "").strip():
         return  # No remote-write configured, no flush task.
     loop = loop or asyncio.get_event_loop()
-    _flush_task = loop.create_task(flush_loop())
+    try:
+        interval = float(os.environ.get("KOMPUTER_METRICS_REMOTE_WRITE_INTERVAL", "15"))
+    except ValueError:
+        interval = 15.0
+    _flush_task = loop.create_task(flush_loop(interval))

--- a/komputer-agent/metrics.py
+++ b/komputer-agent/metrics.py
@@ -164,6 +164,10 @@ def _build_write_request_protobuf() -> bytes:
     parts = []
     for metric_family in REGISTRY.collect():
         for sample in metric_family.samples:
+            # Skip prometheus_client's `_created` timestamp samples — they
+            # pollute the remote series set without adding signal.
+            if sample.name.endswith("_created"):
+                continue
             ts_bytes = _encode_timeseries(sample.name, sample.labels, sample.value, timestamp_ms)
             # field 1 (timeseries), wire type 2 (length-delimited)
             parts.append(_tag_length_value(1, 2, ts_bytes))

--- a/komputer-agent/metrics.py
+++ b/komputer-agent/metrics.py
@@ -1,0 +1,237 @@
+"""Agent-side metrics: collected in-process via prometheus_client and optionally
+pushed to a Prometheus remote-write endpoint.
+
+Three metrics live here because they describe activity that doesn't appear
+in the Redis event stream the API worker consumes:
+- steering: when a follow-up message reroutes a running task
+- mcp_connector_status: per-connector health at MCP server startup
+- subagent_wait_seconds: time spent blocked in wait_for_agents.py
+
+A background flush coroutine pushes these to a Prometheus-compatible
+remote-write endpoint every 15s. Disabled when KOMPUTER_METRICS_REMOTE_WRITE_URL
+is unset.
+"""
+import asyncio
+import logging
+import os
+import struct
+import time as time_mod
+from typing import Optional
+
+import httpx
+import snappy
+from prometheus_client import Counter, Gauge, Histogram, REGISTRY, generate_latest
+
+logger = logging.getLogger("komputer.agent.metrics")
+
+# Module-level metric handles. Initialized in init().
+_steering_total: Optional[Counter] = None
+_mcp_status: Optional[Gauge] = None
+_subagent_wait: Optional[Histogram] = None
+_agent_name_label: str = ""
+_flush_task: Optional[asyncio.Task] = None
+
+
+def _resolve_agent_name() -> str:
+    """Returns the agent name when KOMPUTER_METRICS_PER_AGENT=true, "" otherwise.
+
+    Always present as a label so dashboards stay schema-stable across the flag.
+    """
+    if os.environ.get("KOMPUTER_METRICS_PER_AGENT", "false").lower() == "true":
+        return os.environ.get("KOMPUTER_AGENT_NAME", "")
+    return ""
+
+
+def init():
+    """Initialize the metric handles. Idempotent — safe to call multiple times.
+
+    Note: prometheus_client's REGISTRY is a process-global singleton, so re-initializing
+    requires unregistering existing collectors first. For test isolation we always do that.
+    """
+    global _steering_total, _mcp_status, _subagent_wait, _agent_name_label
+    _agent_name_label = _resolve_agent_name()
+
+    # Unregister any existing collectors with our names (test isolation).
+    for name in (
+        "komputer_agent_steering_total",
+        "komputer_agent_mcp_connector_status",
+        "komputer_agent_subagent_wait_seconds",
+    ):
+        try:
+            collector = REGISTRY._names_to_collectors.get(name)
+            if collector:
+                REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+    _steering_total = Counter(
+        "komputer_agent_steering_total",
+        "Number of times the running agent received a steering follow-up message.",
+        labelnames=["agent_name"],
+    )
+    _mcp_status = Gauge(
+        "komputer_agent_mcp_connector_status",
+        "MCP connector health: 1 if healthy, 0 if unhealthy.",
+        labelnames=["agent_name", "connector", "status"],
+    )
+    _subagent_wait = Histogram(
+        "komputer_agent_subagent_wait_seconds",
+        "Wall-clock time spent in wait_for_agents.py blocked on sub-agents.",
+        labelnames=["agent_name"],
+        buckets=(1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600),
+    )
+
+
+def record_steering():
+    if _steering_total is not None:
+        _steering_total.labels(agent_name=_agent_name_label).inc()
+
+
+def set_mcp_status(connector: str, healthy: bool):
+    if _mcp_status is not None:
+        # Single label "status=healthy" with value 1 (healthy) / 0 (unhealthy)
+        # so PromQL queries like `sum by(connector)` are clean.
+        _mcp_status.labels(
+            agent_name=_agent_name_label, connector=connector, status="healthy"
+        ).set(1.0 if healthy else 0.0)
+
+
+def observe_subagent_wait(seconds: float):
+    if _subagent_wait is not None:
+        _subagent_wait.labels(agent_name=_agent_name_label).observe(seconds)
+
+
+def expose_text() -> bytes:
+    """Return the current registry as Prometheus text format. Used by the
+    /metrics FastAPI route and for the remote-write payload."""
+    return generate_latest(REGISTRY)
+
+
+# --- Remote-write ---
+
+
+async def _flush_once():
+    """Push the current metrics to the remote-write endpoint. Best-effort —
+    log failures, never raise."""
+    url = os.environ.get("KOMPUTER_METRICS_REMOTE_WRITE_URL", "").strip()
+    if not url:
+        return
+    token = os.environ.get("KOMPUTER_METRICS_REMOTE_WRITE_TOKEN", "").strip()
+
+    try:
+        payload = _build_write_request_protobuf()
+    except Exception as e:
+        logger.warning("metrics: failed to build remote-write payload: %s", e)
+        return
+
+    if not payload:
+        return  # nothing to push
+
+    compressed = snappy.compress(payload)
+    headers = {
+        "Content-Type": "application/x-protobuf",
+        "Content-Encoding": "snappy",
+        "X-Prometheus-Remote-Write-Version": "0.1.0",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(url, content=compressed, headers=headers)
+            if resp.status_code >= 300:
+                logger.warning(
+                    "metrics: remote-write returned %d: %s",
+                    resp.status_code, resp.text[:200],
+                )
+    except Exception as e:
+        logger.warning("metrics: remote-write POST failed: %s", e)
+
+
+def _build_write_request_protobuf() -> bytes:
+    """Build a minimal Prometheus WriteRequest protobuf from the REGISTRY state.
+
+    Wire format (https://prometheus.io/docs/concepts/remote_write_spec/):
+      message WriteRequest { repeated TimeSeries timeseries = 1; }
+      message TimeSeries { repeated Label labels = 1; repeated Sample samples = 2; }
+      message Label { string name = 1; string value = 2; }
+      message Sample { double value = 1; int64 timestamp = 2; }
+
+    We hand-roll because the spec is small and stable, avoiding the full
+    prometheus protobuf dependency (which bloats the agent image).
+    """
+    timestamp_ms = int(time_mod.time() * 1000)
+    parts = []
+    for metric_family in REGISTRY.collect():
+        for sample in metric_family.samples:
+            ts_bytes = _encode_timeseries(sample.name, sample.labels, sample.value, timestamp_ms)
+            # field 1 (timeseries), wire type 2 (length-delimited)
+            parts.append(_tag_length_value(1, 2, ts_bytes))
+    return b"".join(parts)
+
+
+def _encode_timeseries(name: str, labels: dict, value: float, timestamp_ms: int) -> bytes:
+    parts = []
+    # The metric name is encoded as the special label __name__.
+    all_labels = {"__name__": name, **labels}
+    for label_name, label_value in all_labels.items():
+        label_bytes = _encode_label(label_name, label_value)
+        parts.append(_tag_length_value(1, 2, label_bytes))  # field 1 (labels)
+    sample_bytes = _encode_sample(value, timestamp_ms)
+    parts.append(_tag_length_value(2, 2, sample_bytes))  # field 2 (samples)
+    return b"".join(parts)
+
+
+def _encode_label(name: str, value: str) -> bytes:
+    name_bytes = name.encode("utf-8")
+    value_bytes = value.encode("utf-8")
+    return _tag_length_value(1, 2, name_bytes) + _tag_length_value(2, 2, value_bytes)
+
+
+def _encode_sample(value: float, timestamp_ms: int) -> bytes:
+    # Sample.value: field 1, wire type 1 (64-bit fixed = double)
+    value_part = bytes([(1 << 3) | 1]) + struct.pack("<d", value)
+    # Sample.timestamp: field 2, wire type 0 (varint = int64)
+    ts_part = bytes([(2 << 3) | 0]) + _encode_varint(timestamp_ms)
+    return value_part + ts_part
+
+
+def _tag_length_value(field_num: int, wire_type: int, data: bytes) -> bytes:
+    tag = (field_num << 3) | wire_type
+    return _encode_varint(tag) + _encode_varint(len(data)) + data
+
+
+def _encode_varint(value: int) -> bytes:
+    parts = bytearray()
+    while value > 0x7F:
+        parts.append((value & 0x7F) | 0x80)
+        value >>= 7
+    parts.append(value & 0x7F)
+    return bytes(parts)
+
+
+# --- Background flush task ---
+
+
+async def flush_loop(interval: float = 15.0):
+    """Background coroutine — flushes metrics every `interval` seconds."""
+    while True:
+        try:
+            await _flush_once()
+        except Exception as e:
+            logger.warning("metrics: flush loop iteration failed: %s", e)
+        await asyncio.sleep(interval)
+
+
+def start_flush_task(loop: Optional[asyncio.AbstractEventLoop] = None):
+    """Start the background flush task. Call once on agent startup.
+
+    No-op when KOMPUTER_METRICS_REMOTE_WRITE_URL is unset (most local dev).
+    """
+    global _flush_task
+    if _flush_task is not None:
+        return
+    if not os.environ.get("KOMPUTER_METRICS_REMOTE_WRITE_URL", "").strip():
+        return  # No remote-write configured, no flush task.
+    loop = loop or asyncio.get_event_loop()
+    _flush_task = loop.create_task(flush_loop())

--- a/komputer-agent/requirements.txt
+++ b/komputer-agent/requirements.txt
@@ -3,3 +3,6 @@ httpx
 redis
 fastapi
 uvicorn
+prometheus-client>=0.20.0
+python-snappy>=0.7.0
+protobuf>=5.0.0

--- a/komputer-agent/scripts/wait_for_agents.py
+++ b/komputer-agent/scripts/wait_for_agents.py
@@ -80,52 +80,67 @@ def main():
 
     print(f"Waiting for {total} agent(s): {', '.join(names)}", file=sys.stderr, flush=True)
 
-    while pending and time.time() < deadline:
-        streams = {info["stream_key"]: info["last_id"] for info in pending.values()}
+    start_time = time.time()
+    try:
+        while pending and time.time() < deadline:
+            streams = {info["stream_key"]: info["last_id"] for info in pending.values()}
 
-        try:
-            resp = r.xread(streams, block=5000, count=100)
-        except redis_lib.RedisError:
-            time.sleep(1)
-            continue
-
-        if not resp:
-            continue
-
-        for stream_key_bytes, entries in resp:
-            stream_key = stream_key_bytes.decode() if isinstance(stream_key_bytes, bytes) else stream_key_bytes
-
-            matched_name = None
-            for name, info in pending.items():
-                if info["stream_key"] == stream_key:
-                    matched_name = name
-                    break
-            if not matched_name:
+            try:
+                resp = r.xread(streams, block=5000, count=100)
+            except redis_lib.RedisError:
+                time.sleep(1)
                 continue
 
-            for entry_id, fields in entries:
-                entry_id_str = entry_id.decode() if isinstance(entry_id, bytes) else entry_id
-                pending[matched_name]["last_id"] = entry_id_str
-                etype = field(fields, "type")
+            if not resp:
+                continue
 
-                # Track the last text event as the agent's output.
-                if etype == "text":
-                    payload_str = field(fields, "payload")
-                    try:
-                        payload = json.loads(payload_str) if payload_str else {}
-                    except json.JSONDecodeError:
-                        payload = {}
-                    pending[matched_name]["last_text"] = payload.get("content", "")
+            for stream_key_bytes, entries in resp:
+                stream_key = stream_key_bytes.decode() if isinstance(stream_key_bytes, bytes) else stream_key_bytes
 
-                if etype in terminal_types:
-                    results[matched_name] = {
-                        "status": etype,
-                        "result": pending[matched_name].get("last_text", ""),
-                    }
-                    del pending[matched_name]
-                    done = total - len(pending)
-                    print(f"[{done}/{total}] {matched_name} -> {etype}", file=sys.stderr, flush=True)
-                    break
+                matched_name = None
+                for name, info in pending.items():
+                    if info["stream_key"] == stream_key:
+                        matched_name = name
+                        break
+                if not matched_name:
+                    continue
+
+                for entry_id, fields in entries:
+                    entry_id_str = entry_id.decode() if isinstance(entry_id, bytes) else entry_id
+                    pending[matched_name]["last_id"] = entry_id_str
+                    etype = field(fields, "type")
+
+                    # Track the last text event as the agent's output.
+                    if etype == "text":
+                        payload_str = field(fields, "payload")
+                        try:
+                            payload = json.loads(payload_str) if payload_str else {}
+                        except json.JSONDecodeError:
+                            payload = {}
+                        pending[matched_name]["last_text"] = payload.get("content", "")
+
+                    if etype in terminal_types:
+                        results[matched_name] = {
+                            "status": etype,
+                            "result": pending[matched_name].get("last_text", ""),
+                        }
+                        del pending[matched_name]
+                        done = total - len(pending)
+                        print(f"[{done}/{total}] {matched_name} -> {etype}", file=sys.stderr, flush=True)
+                        break
+    finally:
+        duration = time.time() - start_time
+        # Push wait duration metric. Script runs as a separate process, so we
+        # init, observe, and force one flush before exit.
+        sys.path.insert(0, "/app")
+        try:
+            import metrics
+            metrics.init()
+            metrics.observe_subagent_wait(duration)
+            import asyncio
+            asyncio.run(metrics._flush_once())
+        except Exception:
+            pass  # never crash the wait script over metrics
 
     for name in pending:
         results[name] = {"status": "timeout"}

--- a/komputer-agent/server.py
+++ b/komputer-agent/server.py
@@ -14,9 +14,15 @@ if not logger.handlers:
 
 from agent import _write_skills
 import config as agent_config
+import metrics as agent_metrics
 import state
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+async def _on_startup():
+    agent_metrics.start_flush_task()
 
 
 @app.exception_handler(HTTPException)
@@ -69,6 +75,12 @@ async def get_status():
 @app.get("/healthz")
 async def healthz():
     return {"status": "ok"}
+
+
+@app.get("/metrics")
+async def metrics_endpoint():
+    from fastapi.responses import Response
+    return Response(content=agent_metrics.expose_text(), media_type="text/plain; version=0.0.4")
 
 
 @app.get("/readyz")
@@ -154,6 +166,7 @@ async def create_task(req: TaskRequest, background_tasks: BackgroundTasks):
         if _publisher:
             _publisher.publish("user_message", {"content": req.instructions, "steer": True})
 
+        agent_metrics.record_steering()
         return {"status": "steered", "instructions": req.instructions[:100]}
 
     # Agent is idle — start a new session as normal.

--- a/komputer-agent/tests/test_metrics.py
+++ b/komputer-agent/tests/test_metrics.py
@@ -1,0 +1,60 @@
+import os
+import pytest
+
+import metrics
+
+
+@pytest.fixture(autouse=True)
+def env_setup(monkeypatch):
+    monkeypatch.setenv("KOMPUTER_AGENT_NAME", "self")
+    monkeypatch.setenv("KOMPUTER_METRICS_PER_AGENT", "true")
+
+
+def test_steering_counter_increments(env_setup):
+    metrics.init()
+    metrics.record_steering()
+    metrics.record_steering()
+    from prometheus_client import REGISTRY
+    val = REGISTRY.get_sample_value(
+        "komputer_agent_steering_total", {"agent_name": "self"}
+    )
+    assert val == 2.0
+
+
+def test_mcp_status_gauge_set(env_setup):
+    metrics.init()
+    metrics.set_mcp_status("slack", healthy=True)
+    metrics.set_mcp_status("github", healthy=False)
+    from prometheus_client import REGISTRY
+    slack_val = REGISTRY.get_sample_value(
+        "komputer_agent_mcp_connector_status",
+        {"agent_name": "self", "connector": "slack", "status": "healthy"}
+    )
+    assert slack_val == 1.0
+    github_val = REGISTRY.get_sample_value(
+        "komputer_agent_mcp_connector_status",
+        {"agent_name": "self", "connector": "github", "status": "healthy"}
+    )
+    assert github_val == 0.0
+
+
+def test_subagent_wait_observed(env_setup):
+    metrics.init()
+    metrics.observe_subagent_wait(5.5)
+    from prometheus_client import REGISTRY
+    count = REGISTRY.get_sample_value(
+        "komputer_agent_subagent_wait_seconds_count", {"agent_name": "self"}
+    )
+    assert count == 1.0
+
+
+def test_per_agent_label_disabled_uses_empty_string(monkeypatch):
+    monkeypatch.setenv("KOMPUTER_METRICS_PER_AGENT", "false")
+    monkeypatch.setenv("KOMPUTER_AGENT_NAME", "actual-name")
+    metrics.init()
+    metrics.record_steering()
+    from prometheus_client import REGISTRY
+    val = REGISTRY.get_sample_value(
+        "komputer_agent_steering_total", {"agent_name": ""}
+    )
+    assert val == 1.0

--- a/komputer-api/go.mod
+++ b/komputer-api/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/komputer-ai/komputer-operator v0.0.0-00010101000000-000000000000
+	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
@@ -61,6 +62,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
@@ -70,7 +72,6 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/komputer-api/handler_agents.go
+++ b/komputer-api/handler_agents.go
@@ -176,10 +176,12 @@ func createOrTriggerAgent(k8s *K8sClient) gin.HandlerFunc {
 					wakeSystemPrompt = existing.Spec.SystemPrompt
 				}
 				if err := k8s.WakeAgent(c.Request.Context(), ns, req.Name, instructions, buildInternalSystemPrompt(wakeMemories), wakeSystemPrompt, req.Model, req.Lifecycle); err != nil {
+					agentActionsTotal.WithLabelValues("wake", "error").Inc()
 					c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to wake agent: " + err.Error()})
 					return
 				}
 				log.Printf("waking sleeping agent %s/%s", ns, req.Name)
+				agentActionsTotal.WithLabelValues("wake", "success").Inc()
 				c.JSON(http.StatusOK, AgentResponse{
 					Name:            existing.Name,
 					Namespace:       existing.Namespace,
@@ -231,6 +233,7 @@ func createOrTriggerAgent(k8s *K8sClient) gin.HandlerFunc {
 			}
 			cw, err := k8s.ForwardTaskToAgent(c.Request.Context(), ns, existing.Status.PodName, podIP, instructions, req.Model, buildInternalSystemPrompt(forwardMemories), forwardSystemPrompt)
 			if err != nil {
+				agentActionsTotal.WithLabelValues("wake", "error").Inc()
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to forward task: " + err.Error()})
 				return
 			}
@@ -248,6 +251,7 @@ func createOrTriggerAgent(k8s *K8sClient) gin.HandlerFunc {
 			}
 
 			log.Printf("forwarded task to existing agent %s/%s", ns, req.Name)
+			agentActionsTotal.WithLabelValues("wake", "success").Inc()
 			c.JSON(http.StatusOK, AgentResponse{
 				Name:            existing.Name,
 				Namespace:       existing.Namespace,
@@ -304,11 +308,13 @@ func createOrTriggerAgent(k8s *K8sClient) gin.HandlerFunc {
 				c.JSON(http.StatusConflict, gin.H{"error": "agent already exists: " + req.Name})
 				return
 			}
+			agentActionsTotal.WithLabelValues("create", "error").Inc()
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create agent: " + err.Error()})
 			return
 		}
 
 		log.Printf("created new agent %s/%s", ns, req.Name)
+		agentActionsTotal.WithLabelValues("create", "success").Inc()
 		c.JSON(http.StatusOK, AgentResponse{
 			Name:         agent.Name,
 			Namespace:    agent.Namespace,
@@ -352,6 +358,7 @@ func deleteAgent(k8s *K8sClient, worker *RedisWorker) gin.HandlerFunc {
 				c.JSON(http.StatusNotFound, gin.H{"error": "agent not found"})
 				return
 			}
+			agentActionsTotal.WithLabelValues("delete", "error").Inc()
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete agent: " + err.Error()})
 			return
 		}
@@ -360,6 +367,7 @@ func deleteAgent(k8s *K8sClient, worker *RedisWorker) gin.HandlerFunc {
 			log.Printf("warning: failed to delete event stream for %s: %v", name, err)
 		}
 		log.Printf("deleted agent %s/%s", ns, name)
+		agentActionsTotal.WithLabelValues("delete", "success").Inc()
 		c.JSON(http.StatusOK, gin.H{"status": "deleted", "name": name})
 	}
 }
@@ -404,11 +412,13 @@ func cancelAgentTask(k8s *K8sClient) gin.HandlerFunc {
 		}
 
 		if err := k8s.CancelAgentTask(c.Request.Context(), ns, agent.Status.PodName, podIP); err != nil {
+			agentActionsTotal.WithLabelValues("cancel", "error").Inc()
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to cancel: " + err.Error()})
 			return
 		}
 
 		log.Printf("cancelled task on agent %s/%s", ns, name)
+		agentActionsTotal.WithLabelValues("cancel", "success").Inc()
 		c.JSON(http.StatusOK, gin.H{"status": "cancelling", "name": name})
 	}
 }
@@ -633,8 +643,15 @@ func patchAgent(k8s *K8sClient) gin.HandlerFunc {
 
 		var nonFatalErrors []string
 
+		// Determine action label for metrics: "sleep" if lifecycle → Sleep, else "patch".
+		patchAction := "patch"
+		if req.Lifecycle != nil && *req.Lifecycle == "Sleep" {
+			patchAction = "sleep"
+		}
+
 		// 1. Patch CR spec first — this is the source of truth.
 		if err := k8s.PatchAgentSpec(c.Request.Context(), ns, name, req.Model, req.Lifecycle, req.Instructions, req.TemplateRef, req.SystemPrompt, req.Priority); err != nil {
+			agentActionsTotal.WithLabelValues(patchAction, "error").Inc()
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to patch agent: " + err.Error()})
 			return
 		}
@@ -642,6 +659,7 @@ func patchAgent(k8s *K8sClient) gin.HandlerFunc {
 		// 1a-override. Patch podSpec / storage overrides if provided.
 		if req.PodSpec != nil || req.Storage != nil {
 			if err := k8s.PatchAgentOverrides(c.Request.Context(), ns, name, req.PodSpec, req.Storage); err != nil {
+				agentActionsTotal.WithLabelValues(patchAction, "error").Inc()
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to patch agent overrides: " + err.Error()})
 				return
 			}
@@ -741,6 +759,7 @@ func patchAgent(k8s *K8sClient) gin.HandlerFunc {
 		// 3. Return updated agent.
 		updated, err := k8s.GetAgent(c.Request.Context(), ns, name)
 		if err != nil {
+			agentActionsTotal.WithLabelValues(patchAction, "error").Inc()
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "agent patched but failed to read back: " + err.Error()})
 			return
 		}
@@ -749,6 +768,7 @@ func patchAgent(k8s *K8sClient) gin.HandlerFunc {
 		if freshContextWindow > 0 {
 			modelContextWindow = freshContextWindow
 		}
+		agentActionsTotal.WithLabelValues(patchAction, "success").Inc()
 		c.JSON(http.StatusOK, AgentResponse{
 			Name:            updated.Name,
 			Namespace:       updated.Namespace,

--- a/komputer-api/metrics.go
+++ b/komputer-api/metrics.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -39,6 +43,38 @@ var (
 		[]string{"namespace", "model", "outcome", "agent_name"},
 	)
 
+	httpRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "komputer_api_http_request_duration_seconds",
+			Help:    "Wall-clock duration of HTTP requests handled by the API.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method", "path"},
+	)
+
+	wsConnectionsActive = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "komputer_api_ws_connections_active",
+			Help: "Currently open WebSocket connections to /agents/:name/ws.",
+		},
+		[]string{"mode"}, // broadcast or group
+	)
+
+	wsDispatchTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "komputer_api_ws_dispatch_total",
+			Help: "Events dispatched to WebSocket clients.",
+		},
+		[]string{"mode", "result"}, // mode=broadcast|group, result=delivered|claimed_by_other|write_failed
+	)
+
+	redisXreadMessagesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "komputer_api_redis_xread_messages_total",
+			Help: "Total messages read from Redis streams by the broadcast worker.",
+		},
+	)
+
 	// Build-info gauges (value=1) give each registry at least one active metric
 	// and expose version information to dashboards.
 	apiBuildInfo = prometheus.NewGaugeVec(
@@ -67,6 +103,10 @@ func newMetricsRegistries(perAgentLabels bool) (*prometheus.Registry, *prometheu
 	agentRegistry = prometheus.NewRegistry()
 
 	apiRegistry.MustRegister(httpRequestsTotal)
+	apiRegistry.MustRegister(httpRequestDuration)
+	apiRegistry.MustRegister(wsConnectionsActive)
+	apiRegistry.MustRegister(wsDispatchTotal)
+	apiRegistry.MustRegister(redisXreadMessagesTotal)
 	apiRegistry.MustRegister(apiBuildInfo)
 	agentRegistry.MustRegister(agentTasksTotal)
 	agentRegistry.MustRegister(agentBuildInfo)
@@ -84,4 +124,21 @@ func agentNameLabel(name string) string {
 		return name
 	}
 	return ""
+}
+
+// metricsMiddleware records HTTP request count and duration for every handled request.
+// Path is the route template (e.g. "/agents/:name") so cardinality stays bounded.
+func metricsMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		c.Next()
+		path := c.FullPath()
+		if path == "" {
+			path = "unmatched"
+		}
+		method := c.Request.Method
+		status := strconv.Itoa(c.Writer.Status())
+		httpRequestsTotal.WithLabelValues(method, path, status).Inc()
+		httpRequestDuration.WithLabelValues(method, path).Observe(time.Since(start).Seconds())
+	}
 }

--- a/komputer-api/metrics.go
+++ b/komputer-api/metrics.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
+	komputerv1alpha1 "github.com/komputer-ai/komputer-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Populated at build time via -ldflags "-X main.version=... -X main.commit=..."
@@ -208,6 +212,87 @@ func (t *toolCallTrackerT) consumeDuration(agent, toolUseID string, endAt time.T
 	}
 	delete(t.starts, key)
 	return endAt.Sub(startAt), true
+}
+
+// crCollector lists KomputerAgent and KomputerSchedule CRs at scrape time
+// and exposes counts as gauges. No goroutines, no cache drift.
+// Implements prometheus.Collector.
+type crCollector struct {
+	k8s *K8sClient
+
+	tasksInProgress *prometheus.Desc
+	schedulesActive *prometheus.Desc
+	agentsByPhase   *prometheus.Desc
+}
+
+func newCRCollector(k8s *K8sClient) *crCollector {
+	return &crCollector{
+		k8s: k8s,
+		tasksInProgress: prometheus.NewDesc(
+			"komputer_tasks_inprogress",
+			"Number of agent tasks currently in progress (taskStatus=InProgress).",
+			// agent_name is always present so dashboards stay schema-stable.
+			// Empty string when KOMPUTER_METRICS_PER_AGENT=false, real name when true.
+			[]string{"namespace", "model", "agent_name"}, nil,
+		),
+		schedulesActive: prometheus.NewDesc(
+			"komputer_schedules_active",
+			"Number of KomputerSchedule resources defined.",
+			[]string{"namespace"}, nil,
+		),
+		agentsByPhase: prometheus.NewDesc(
+			"komputer_agents_active",
+			"Number of agents in each lifecycle phase.",
+			[]string{"namespace", "phase"}, nil,
+		),
+	}
+}
+
+func (c *crCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.tasksInProgress
+	ch <- c.schedulesActive
+	ch <- c.agentsByPhase
+}
+
+func (c *crCollector) Collect(ch chan<- prometheus.Metric) {
+	// 5s timeout: scrapes that take longer get truncated. Caller (Prometheus) typically
+	// gives us 10s before giving up entirely, so this leaves headroom.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var agents komputerv1alpha1.KomputerAgentList
+	if err := c.k8s.client.List(ctx, &agents, &client.ListOptions{LabelSelector: labels.Everything()}); err == nil {
+		// tasksInProgress: when perAgentLabels=true, one series per agent (value=1).
+		// When false, aggregated by (namespace, model) with agent_name="" (sum is the count).
+		inProg := map[[3]string]int{} // (namespace, model, agent_name) -> count
+		// agentsByPhase: always aggregated count per (namespace, phase).
+		byPhase := map[[2]string]int{} // (namespace, phase) -> count
+		for _, a := range agents.Items {
+			byPhase[[2]string{a.Namespace, string(a.Status.Phase)}]++
+			if a.Status.TaskStatus == "InProgress" {
+				inProg[[3]string{a.Namespace, a.Spec.Model, agentNameLabel(a.Name)}]++
+			}
+		}
+		for k, v := range inProg {
+			ch <- prometheus.MustNewConstMetric(c.tasksInProgress, prometheus.GaugeValue, float64(v), k[0], k[1], k[2])
+		}
+		for k, v := range byPhase {
+			ch <- prometheus.MustNewConstMetric(c.agentsByPhase, prometheus.GaugeValue, float64(v), k[0], k[1])
+		}
+	}
+	// List errors are silently dropped — we don't have a good way to expose collector errors
+	// through the standard interface. The metric just won't appear that scrape.
+
+	var schedules komputerv1alpha1.KomputerScheduleList
+	if err := c.k8s.client.List(ctx, &schedules); err == nil {
+		byNs := map[string]int{}
+		for _, s := range schedules.Items {
+			byNs[s.Namespace]++
+		}
+		for ns, v := range byNs {
+			ch <- prometheus.MustNewConstMetric(c.schedulesActive, prometheus.GaugeValue, float64(v), ns)
+		}
+	}
 }
 
 // metricsMiddleware records HTTP request count and duration for every handled request.

--- a/komputer-api/metrics.go
+++ b/komputer-api/metrics.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Populated at build time via -ldflags "-X main.version=... -X main.commit=..."
+var (
+	version = "dev"
+	commit  = "unknown"
+)
+
+// perAgentLabelsEnabled controls whether agent_name appears as a real value or ""
+// on per-agent metrics. Set once at startup.
+var perAgentLabelsEnabled bool
+
+// Two separate registries — kept apart so /api/metrics and /agent/metrics
+// can be scraped by different ServiceMonitors with different retention/cardinality
+// budgets if the operator wants.
+var (
+	apiRegistry   *prometheus.Registry
+	agentRegistry *prometheus.Registry
+)
+
+// Per-registry metric handles. Initialized eagerly so they are always non-nil.
+var (
+	httpRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "komputer_api_http_requests_total",
+			Help: "Total HTTP requests received by the API.",
+		},
+		[]string{"method", "path", "status"},
+	)
+	agentTasksTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "komputer_agent_tasks_total",
+			Help: "Total agent task lifecycle transitions (started, completed, cancelled, errored).",
+		},
+		[]string{"namespace", "model", "outcome", "agent_name"},
+	)
+
+	// Build-info gauges (value=1) give each registry at least one active metric
+	// and expose version information to dashboards.
+	apiBuildInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "komputer_api_build_info",
+			Help: "Always 1; exposes build metadata labels for dashboards.",
+		},
+		[]string{"version", "commit"},
+	)
+	agentBuildInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "komputer_agent_build_info",
+			Help: "Always 1; exposes build metadata labels for dashboards.",
+		},
+		[]string{"version", "commit"},
+	)
+)
+
+// newMetricsRegistries creates fresh registries and registers all metric handles.
+// Called once from SetupRoutes. The perAgentLabels flag controls whether
+// agent_name appears as a real value or as the empty string on per-agent metrics.
+func newMetricsRegistries(perAgentLabels bool) (*prometheus.Registry, *prometheus.Registry) {
+	perAgentLabelsEnabled = perAgentLabels
+
+	apiRegistry = prometheus.NewRegistry()
+	agentRegistry = prometheus.NewRegistry()
+
+	apiRegistry.MustRegister(httpRequestsTotal)
+	apiRegistry.MustRegister(apiBuildInfo)
+	agentRegistry.MustRegister(agentTasksTotal)
+	agentRegistry.MustRegister(agentBuildInfo)
+
+	apiBuildInfo.WithLabelValues(version, commit).Set(1)
+	agentBuildInfo.WithLabelValues(version, commit).Set(1)
+
+	return apiRegistry, agentRegistry
+}
+
+// agentNameLabel returns the agent name when perAgentLabels is enabled, "" otherwise.
+// Always include this in the label set on per-agent metrics so dashboards stay schema-stable.
+func agentNameLabel(name string) string {
+	if perAgentLabelsEnabled {
+		return name
+	}
+	return ""
+}

--- a/komputer-api/metrics.go
+++ b/komputer-api/metrics.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"strconv"
 	"sync"
 	"time"
@@ -146,6 +147,13 @@ var (
 		},
 		[]string{"version", "commit"},
 	)
+	crCollectorErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "komputer_api_cr_collector_errors_total",
+			Help: "Failed CR list calls during /agent/metrics scrape, by resource.",
+		},
+		[]string{"resource"},
+	)
 )
 
 // newMetricsRegistries creates fresh registries and registers all metric handles.
@@ -171,6 +179,7 @@ func newMetricsRegistries(perAgentLabels bool) (*prometheus.Registry, *prometheu
 	agentRegistry.MustRegister(agentToolDuration)
 	agentRegistry.MustRegister(agentActionsTotal)
 	agentRegistry.MustRegister(agentBuildInfo)
+	agentRegistry.MustRegister(crCollectorErrorsTotal)
 
 	apiBuildInfo.WithLabelValues(version, commit).Set(1)
 	agentBuildInfo.WithLabelValues(version, commit).Set(1)
@@ -261,7 +270,10 @@ func (c *crCollector) Collect(ch chan<- prometheus.Metric) {
 	defer cancel()
 
 	var agents komputerv1alpha1.KomputerAgentList
-	if err := c.k8s.client.List(ctx, &agents, &client.ListOptions{LabelSelector: labels.Everything()}); err == nil {
+	if err := c.k8s.client.List(ctx, &agents, &client.ListOptions{LabelSelector: labels.Everything()}); err != nil {
+		log.Printf("crCollector: failed to list KomputerAgents: %v", err)
+		crCollectorErrorsTotal.WithLabelValues("agents").Inc()
+	} else {
 		// tasksInProgress: when perAgentLabels=true, one series per agent (value=1).
 		// When false, aggregated by (namespace, model) with agent_name="" (sum is the count).
 		inProg := map[[3]string]int{} // (namespace, model, agent_name) -> count
@@ -280,11 +292,12 @@ func (c *crCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(c.agentsByPhase, prometheus.GaugeValue, float64(v), k[0], k[1])
 		}
 	}
-	// List errors are silently dropped — we don't have a good way to expose collector errors
-	// through the standard interface. The metric just won't appear that scrape.
 
 	var schedules komputerv1alpha1.KomputerScheduleList
-	if err := c.k8s.client.List(ctx, &schedules); err == nil {
+	if err := c.k8s.client.List(ctx, &schedules); err != nil {
+		log.Printf("crCollector: failed to list KomputerSchedules: %v", err)
+		crCollectorErrorsTotal.WithLabelValues("schedules").Inc()
+	} else {
 		byNs := map[string]int{}
 		for _, s := range schedules.Items {
 			byNs[s.Namespace]++
@@ -294,6 +307,7 @@ func (c *crCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 	}
 }
+
 
 // metricsMiddleware records HTTP request count and duration for every handled request.
 // Path is the route template (e.g. "/agents/:name") so cardinality stays bounded.

--- a/komputer-api/metrics.go
+++ b/komputer-api/metrics.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -38,9 +39,59 @@ var (
 	agentTasksTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "komputer_agent_tasks_total",
-			Help: "Total agent task lifecycle transitions (started, completed, cancelled, errored).",
+			Help: "Total agent task lifecycle transitions.",
 		},
 		[]string{"namespace", "model", "outcome", "agent_name"},
+	)
+
+	agentTaskDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "komputer_agent_task_duration_seconds",
+			Help:    "Wall-clock duration of completed agent tasks.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 12), // 1s, 2s, ... ~1h
+		},
+		[]string{"namespace", "model", "agent_name"},
+	)
+
+	agentTaskCostUSD = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "komputer_agent_task_cost_usd_total",
+			Help: "Total cost in USD across all completed agent tasks.",
+		},
+		[]string{"namespace", "model", "agent_name"},
+	)
+
+	agentTaskTokens = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "komputer_agent_task_tokens_total",
+			Help: "Total tokens used across all completed agent tasks.",
+		},
+		[]string{"namespace", "model", "kind", "agent_name"},
+	)
+
+	agentToolInvocations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "komputer_agent_tool_invocations_total",
+			Help: "Total tool invocations by tool name and outcome.",
+		},
+		[]string{"namespace", "tool", "outcome", "agent_name"},
+	)
+
+	agentToolDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "komputer_agent_tool_duration_seconds",
+			Help:    "Tool execution duration, derived from tool_call/tool_result event pairs.",
+			Buckets: prometheus.ExponentialBuckets(0.1, 2, 12), // 100ms, 200ms, ... ~7min
+		},
+		[]string{"namespace", "tool", "agent_name"},
+	)
+
+	agentActionsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "komputer_agent_actions_total",
+			Help: "Agent management actions taken via the API (create/delete/cancel/sleep/wake/patch).",
+		},
+		[]string{"action", "result"},
 	)
 
 	httpRequestDuration = prometheus.NewHistogramVec(
@@ -109,6 +160,12 @@ func newMetricsRegistries(perAgentLabels bool) (*prometheus.Registry, *prometheu
 	apiRegistry.MustRegister(redisXreadMessagesTotal)
 	apiRegistry.MustRegister(apiBuildInfo)
 	agentRegistry.MustRegister(agentTasksTotal)
+	agentRegistry.MustRegister(agentTaskDuration)
+	agentRegistry.MustRegister(agentTaskCostUSD)
+	agentRegistry.MustRegister(agentTaskTokens)
+	agentRegistry.MustRegister(agentToolInvocations)
+	agentRegistry.MustRegister(agentToolDuration)
+	agentRegistry.MustRegister(agentActionsTotal)
 	agentRegistry.MustRegister(agentBuildInfo)
 
 	apiBuildInfo.WithLabelValues(version, commit).Set(1)
@@ -124,6 +181,33 @@ func agentNameLabel(name string) string {
 		return name
 	}
 	return ""
+}
+
+// toolCallTrackerT correlates tool_call → tool_result events to compute tool execution duration.
+type toolCallTrackerT struct {
+	mu     sync.Mutex
+	starts map[string]time.Time // key = "<agent>:<tool_use_id>"
+}
+
+var toolCallTracker = &toolCallTrackerT{starts: make(map[string]time.Time)}
+
+func (t *toolCallTrackerT) markStart(agent, toolUseID string, at time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.starts[agent+":"+toolUseID] = at
+}
+
+// consumeDuration returns the time between markStart and now, deleting the entry. Returns false if no start was tracked.
+func (t *toolCallTrackerT) consumeDuration(agent, toolUseID string, endAt time.Time) (time.Duration, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	key := agent + ":" + toolUseID
+	startAt, ok := t.starts[key]
+	if !ok {
+		return 0, false
+	}
+	delete(t.starts, key)
+	return endAt.Sub(startAt), true
 }
 
 // metricsMiddleware records HTTP request count and duration for every handled request.

--- a/komputer-api/metrics_test.go
+++ b/komputer-api/metrics_test.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestRegistriesAreSeparate(t *testing.T) {
@@ -37,5 +42,40 @@ func TestPerAgentLabelDisabled(t *testing.T) {
 	_, _ = newMetricsRegistries(false)
 	if perAgentLabelsEnabled {
 		t.Errorf("expected perAgentLabels=false after construction with false")
+	}
+}
+
+func TestHTTPMiddlewareIncrementsCounter(t *testing.T) {
+	_, _ = newMetricsRegistries(false)
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(metricsMiddleware())
+	r.GET("/foo", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) })
+
+	req := httptest.NewRequest("GET", "/foo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	count := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "/foo", "200"))
+	if count != 1 {
+		t.Errorf("expected 1 request counted, got %v", count)
+	}
+}
+
+func TestHTTPMiddlewareObservesDuration(t *testing.T) {
+	_, _ = newMetricsRegistries(false)
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(metricsMiddleware())
+	r.GET("/bar", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) })
+
+	req := httptest.NewRequest("GET", "/bar", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Histogram count should be 1 after one request
+	count := testutil.CollectAndCount(httpRequestDuration)
+	if count == 0 {
+		t.Errorf("expected histogram to have observations")
 	}
 }

--- a/komputer-api/metrics_test.go
+++ b/komputer-api/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
@@ -78,6 +79,20 @@ func TestHTTPMiddlewareObservesDuration(t *testing.T) {
 	count := testutil.CollectAndCount(httpRequestDuration)
 	if count == 0 {
 		t.Errorf("expected histogram to have observations")
+	}
+}
+
+func TestCRCollectorEmitsExpectedDescriptors(t *testing.T) {
+	c := newCRCollector(nil) // k8s nil — Collect will silently skip due to error returns
+	ch := make(chan *prometheus.Desc, 3)
+	c.Describe(ch)
+	close(ch)
+	descs := []*prometheus.Desc{}
+	for d := range ch {
+		descs = append(descs, d)
+	}
+	if len(descs) != 3 {
+		t.Errorf("expected 3 descriptors, got %d", len(descs))
 	}
 }
 

--- a/komputer-api/metrics_test.go
+++ b/komputer-api/metrics_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestRegistriesAreSeparate(t *testing.T) {
+	apiReg, agentReg := newMetricsRegistries(false)
+	if apiReg == agentReg {
+		t.Fatal("api and agent registries must be different instances")
+	}
+	// Verify the api registry is independently gatherable (not the global default).
+	apiMetrics, err := apiReg.Gather()
+	if err != nil {
+		t.Fatalf("api gather: %v", err)
+	}
+	if len(apiMetrics) == 0 {
+		t.Errorf("expected api registry to have metrics, got 0")
+	}
+	agentMetrics, err := agentReg.Gather()
+	if err != nil {
+		t.Fatalf("agent gather: %v", err)
+	}
+	if len(agentMetrics) == 0 {
+		t.Errorf("expected agent registry to have metrics, got 0")
+	}
+}
+
+func TestPerAgentLabelEnabled(t *testing.T) {
+	_, _ = newMetricsRegistries(true)
+	if !perAgentLabelsEnabled {
+		t.Errorf("expected perAgentLabels=true after construction with true")
+	}
+}
+
+func TestPerAgentLabelDisabled(t *testing.T) {
+	_, _ = newMetricsRegistries(false)
+	if perAgentLabelsEnabled {
+		t.Errorf("expected perAgentLabels=false after construction with false")
+	}
+}

--- a/komputer-api/metrics_test.go
+++ b/komputer-api/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -77,5 +78,22 @@ func TestHTTPMiddlewareObservesDuration(t *testing.T) {
 	count := testutil.CollectAndCount(httpRequestDuration)
 	if count == 0 {
 		t.Errorf("expected histogram to have observations")
+	}
+}
+
+func TestToolCallTracker(t *testing.T) {
+	toolCallTracker = &toolCallTrackerT{starts: make(map[string]time.Time)}
+	start := time.Now()
+	toolCallTracker.markStart("foo-agent", "tc_01", start)
+	dur, ok := toolCallTracker.consumeDuration("foo-agent", "tc_01", start.Add(2*time.Second))
+	if !ok {
+		t.Fatal("expected to find start time")
+	}
+	if dur != 2*time.Second {
+		t.Errorf("expected 2s, got %v", dur)
+	}
+	// Second consume should fail (already consumed).
+	if _, ok := toolCallTracker.consumeDuration("foo-agent", "tc_01", time.Now()); ok {
+		t.Error("expected second consume to fail")
 	}
 }

--- a/komputer-api/routes.go
+++ b/komputer-api/routes.go
@@ -41,6 +41,7 @@ func SetupRoutes(r *gin.Engine, k8s *K8sClient, hub *Hub, worker *RedisWorker) {
 	// Metrics — two separate registries scraped by different ServiceMonitors.
 	perAgentLabels := os.Getenv("KOMPUTER_METRICS_PER_AGENT") == "true"
 	apiReg, agentReg := newMetricsRegistries(perAgentLabels)
+	agentReg.MustRegister(newCRCollector(k8s))
 	r.GET("/api/metrics", gin.WrapH(promhttp.HandlerFor(apiReg, promhttp.HandlerOpts{Registry: apiReg})))
 	r.GET("/agent/metrics", gin.WrapH(promhttp.HandlerFor(agentReg, promhttp.HandlerOpts{Registry: agentReg})))
 

--- a/komputer-api/routes.go
+++ b/komputer-api/routes.go
@@ -44,6 +44,9 @@ func SetupRoutes(r *gin.Engine, k8s *K8sClient, hub *Hub, worker *RedisWorker) {
 	r.GET("/api/metrics", gin.WrapH(promhttp.HandlerFor(apiReg, promhttp.HandlerOpts{Registry: apiReg})))
 	r.GET("/agent/metrics", gin.WrapH(promhttp.HandlerFor(agentReg, promhttp.HandlerOpts{Registry: agentReg})))
 
+	// HTTP instrumentation — records request count and duration for all routes.
+	r.Use(metricsMiddleware())
+
 	// Health check endpoints (outside /api/v1 for k8s probes).
 	r.GET("/healthz", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})

--- a/komputer-api/routes.go
+++ b/komputer-api/routes.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"net/http"
+	"os"
 	"regexp"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // isValidK8sName checks if a string is a valid Kubernetes DNS subdomain name.
@@ -36,6 +38,12 @@ func collectSecretKeys(ctx gin.Context, k8s *K8sClient, ns string, secretNames [
 }
 
 func SetupRoutes(r *gin.Engine, k8s *K8sClient, hub *Hub, worker *RedisWorker) {
+	// Metrics — two separate registries scraped by different ServiceMonitors.
+	perAgentLabels := os.Getenv("KOMPUTER_METRICS_PER_AGENT") == "true"
+	apiReg, agentReg := newMetricsRegistries(perAgentLabels)
+	r.GET("/api/metrics", gin.WrapH(promhttp.HandlerFor(apiReg, promhttp.HandlerOpts{Registry: apiReg})))
+	r.GET("/agent/metrics", gin.WrapH(promhttp.HandlerFor(agentReg, promhttp.HandlerOpts{Registry: agentReg})))
+
 	// Health check endpoints (outside /api/v1 for k8s probes).
 	r.GET("/healthz", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})

--- a/komputer-api/worker.go
+++ b/komputer-api/worker.go
@@ -277,6 +277,7 @@ func StartRedisWorker(ctx context.Context, cfg RedisWorkerConfig, k8s *K8sClient
 			for _, stream := range results {
 				for _, msg := range stream.Messages {
 					lastIDs[stream.Stream] = msg.ID
+					redisXreadMessagesTotal.Inc()
 
 					event, err := parseStreamMessage(msg)
 					if err != nil {

--- a/komputer-api/worker.go
+++ b/komputer-api/worker.go
@@ -140,6 +140,65 @@ func StartRedisWorker(ctx context.Context, cfg RedisWorkerConfig, k8s *K8sClient
 						continue
 					}
 
+					// --- metric emission ---
+					model := ""
+					if m, ok := event.Payload["model"].(string); ok {
+						model = m
+					}
+					agentLabel := agentNameLabel(event.AgentName)
+
+					switch event.Type {
+					case "task_started":
+						agentTasksTotal.WithLabelValues(event.Namespace, model, "started", agentLabel).Inc()
+					case "task_completed":
+						agentTasksTotal.WithLabelValues(event.Namespace, model, "completed", agentLabel).Inc()
+						if cost, ok := event.Payload["cost_usd"].(float64); ok {
+							agentTaskCostUSD.WithLabelValues(event.Namespace, model, agentLabel).Add(cost)
+						}
+						if dur, ok := event.Payload["duration_ms"].(float64); ok {
+							agentTaskDuration.WithLabelValues(event.Namespace, model, agentLabel).Observe(dur / 1000.0)
+						}
+						if usage, ok := event.Payload["last_usage"].(map[string]interface{}); ok {
+							for kindKey, label := range map[string]string{
+								"input_tokens":                "input",
+								"output_tokens":               "output",
+								"cache_read_input_tokens":     "cache_read",
+								"cache_creation_input_tokens": "cache_creation",
+							} {
+								if v, ok := usage[kindKey].(float64); ok {
+									agentTaskTokens.WithLabelValues(event.Namespace, model, label, agentLabel).Add(v)
+								}
+							}
+						}
+					case "task_cancelled":
+						agentTasksTotal.WithLabelValues(event.Namespace, model, "cancelled", agentLabel).Inc()
+					case "error":
+						agentTasksTotal.WithLabelValues(event.Namespace, model, "errored", agentLabel).Inc()
+					case "tool_call":
+						if toolName, ok := event.Payload["tool"].(string); ok && toolName != "" {
+							if toolUseID, ok := event.Payload["id"].(string); ok && toolUseID != "" {
+								toolCallTracker.markStart(event.AgentName, toolUseID, time.Now())
+							}
+						}
+					case "tool_result":
+						toolName, _ := event.Payload["tool"].(string)
+						toolUseID, _ := event.Payload["id"].(string)
+						isError, _ := event.Payload["is_error"].(bool)
+						outcome := "success"
+						if isError {
+							outcome = "error"
+						}
+						if toolName != "" {
+							agentToolInvocations.WithLabelValues(event.Namespace, toolName, outcome, agentLabel).Inc()
+							if toolUseID != "" {
+								if dur, ok := toolCallTracker.consumeDuration(event.AgentName, toolUseID, time.Now()); ok {
+									agentToolDuration.WithLabelValues(event.Namespace, toolName, agentLabel).Observe(dur.Seconds())
+								}
+							}
+						}
+					}
+					// --- end metric emission ---
+
 					raw, err := json.Marshal(event)
 					if err != nil {
 						log.Printf("failed to marshal event: %v", err)

--- a/komputer-api/ws.go
+++ b/komputer-api/ws.go
@@ -47,6 +47,7 @@ func (h *Hub) SubscribeBroadcast(agentName string, conn *websocket.Conn) {
 		h.broadcast[agentName] = make(map[*websocket.Conn]struct{})
 	}
 	h.broadcast[agentName][conn] = struct{}{}
+	wsConnectionsActive.WithLabelValues("broadcast").Inc()
 }
 
 // SubscribeGroup adds a connection to a named group. Within the group, each
@@ -61,6 +62,7 @@ func (h *Hub) SubscribeGroup(agentName, group string, conn *websocket.Conn) {
 		h.groups[agentName][group] = make(map[*websocket.Conn]struct{})
 	}
 	h.groups[agentName][group][conn] = struct{}{}
+	wsConnectionsActive.WithLabelValues("group").Inc()
 }
 
 // Unsubscribe removes a connection from broadcast and any groups for the agent.
@@ -68,15 +70,19 @@ func (h *Hub) Unsubscribe(agentName string, conn *websocket.Conn) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if clients, ok := h.broadcast[agentName]; ok {
-		delete(clients, conn)
-		if len(clients) == 0 {
-			delete(h.broadcast, agentName)
+		if _, had := clients[conn]; had {
+			delete(clients, conn)
+			wsConnectionsActive.WithLabelValues("broadcast").Dec()
+			if len(clients) == 0 {
+				delete(h.broadcast, agentName)
+			}
 		}
 	}
 	if perGroup, ok := h.groups[agentName]; ok {
 		for group, clients := range perGroup {
 			if _, has := clients[conn]; has {
 				delete(clients, conn)
+				wsConnectionsActive.WithLabelValues("group").Dec()
 				if len(clients) == 0 {
 					delete(perGroup, group)
 				}
@@ -116,8 +122,11 @@ func (h *Hub) Dispatch(ctx context.Context, agentName, msgID string, message []b
 	// Broadcast bucket: send to all.
 	for _, conn := range bcast {
 		if err := conn.WriteMessage(websocket.TextMessage, message); err != nil {
+			wsDispatchTotal.WithLabelValues("broadcast", "write_failed").Inc()
 			conn.Close()
 			h.Unsubscribe(agentName, conn)
+		} else {
+			wsDispatchTotal.WithLabelValues("broadcast", "delivered").Inc()
 		}
 	}
 
@@ -127,6 +136,7 @@ func (h *Hub) Dispatch(ctx context.Context, agentName, msgID string, message []b
 		claimKey := "wsclaim:" + agentName + ":" + group + ":" + msgID
 		ok, err := h.rdb.SetNX(ctx, claimKey, h.replicaID, h.claimTTL).Result()
 		if err != nil || !ok {
+			wsDispatchTotal.WithLabelValues("group", "claimed_by_other").Inc()
 			continue
 		}
 
@@ -143,11 +153,13 @@ func (h *Hub) Dispatch(ctx context.Context, agentName, msgID string, message []b
 				h.Unsubscribe(agentName, pick)
 				continue // try next member in this group
 			}
+			wsDispatchTotal.WithLabelValues("group", "delivered").Inc()
 			delivered = true
 			break
 		}
 
 		if !delivered {
+			wsDispatchTotal.WithLabelValues("group", "write_failed").Inc()
 			// All local members failed. Release the claim so a future event
 			// re-evaluates routing (a different replica may have live members).
 			// This event itself is lost for the group; clients reconcile via REST history.

--- a/komputer-operator/cmd/main.go
+++ b/komputer-operator/cmd/main.go
@@ -64,8 +64,8 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
-	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
-		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8082", "The address the metrics endpoint binds to. "+
+		"Use :8443 for HTTPS or :8082 for HTTP, or set to 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/komputer-operator/config/samples/komputer_v1alpha1_komputeragentclustertemplate.yaml
+++ b/komputer-operator/config/samples/komputer_v1alpha1_komputeragentclustertemplate.yaml
@@ -14,12 +14,19 @@ spec:
               secretKeyRef:
                 name: anthropic-api-key
                 key: api-key
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "256Mi"
-          limits:
-            cpu: "2"
-            memory: "2Gi"
+          # Push agent-side metrics to the local Prometheus started via
+          # `monitoring/docker-compose.yml` on the host. Prometheus there has
+          # --web.enable-remote-write-receiver enabled. Comment out to disable.
+          - name: KOMPUTER_METRICS_PER_AGENT
+            value: "true"
+          - name: KOMPUTER_METRICS_REMOTE_WRITE_URL
+            value: "http://host.docker.internal:9090/api/v1/write"
+        # resources:
+        #   requests:
+        #     cpu: "100m"
+        #     memory: "256Mi"
+        #   limits:
+        #     cpu: "2"
+        #     memory: "2Gi"
   storage:
     size: "5Gi"

--- a/komputer-operator/go.mod
+++ b/komputer-operator/go.mod
@@ -5,6 +5,9 @@ go 1.24.0
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
+	github.com/prometheus/client_golang v1.22.0
+	github.com/robfig/cron/v3 v3.0.1
+	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
 	sigs.k8s.io/controller-runtime v0.21.0
@@ -41,16 +44,15 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
@@ -83,7 +85,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.33.0 // indirect
 	k8s.io/apiextensions-apiserver v0.33.0 // indirect
 	k8s.io/apiserver v0.33.0 // indirect
 	k8s.io/component-base v0.33.0 // indirect

--- a/komputer-operator/internal/controller/komputeragent_controller.go
+++ b/komputer-operator/internal/controller/komputeragent_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	komputerv1alpha1 "github.com/komputer-ai/komputer-operator/api/v1alpha1"
+	operatormetrics "github.com/komputer-ai/komputer-operator/internal/metrics"
 )
 
 // KomputerAgentReconciler reconciles a KomputerAgent object
@@ -136,6 +137,7 @@ func (r *KomputerAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		decision := evaluateAdmission(agent, siblings, admissionCap)
 		if !decision.Admit {
+			operatormetrics.TemplateCapReachedTotal.WithLabelValues(agent.Namespace, templateRef).Inc()
 			if err := r.updateStatus(ctx, agent, func(s *komputerv1alpha1.KomputerAgentStatus) {
 				s.Phase = komputerv1alpha1.AgentPhaseQueued
 				s.QueuePosition = decision.Position

--- a/komputer-operator/internal/metrics/metrics.go
+++ b/komputer-operator/internal/metrics/metrics.go
@@ -1,0 +1,21 @@
+// Package metrics holds the operator's custom Prometheus metrics.
+// They register on controller-runtime's global metrics registry, so they
+// appear at the same /metrics endpoint as the built-in reconcile metrics.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var TemplateCapReachedTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "komputer_operator_template_cap_reached_total",
+		Help: "Number of times agent admission was denied because the template's maxConcurrentAgents was reached.",
+	},
+	[]string{"namespace", "template"},
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(TemplateCapReachedTotal)
+}

--- a/komputer-operator/internal/metrics/metrics_test.go
+++ b/komputer-operator/internal/metrics/metrics_test.go
@@ -1,0 +1,15 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestTemplateCapReachedRegistered(t *testing.T) {
+	TemplateCapReachedTotal.WithLabelValues("default", "small").Inc()
+	count := testutil.ToFloat64(TemplateCapReachedTotal.WithLabelValues("default", "small"))
+	if count < 1 {
+		t.Errorf("expected at least 1, got %v", count)
+	}
+}

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -34,10 +34,18 @@ The Komputer Overview dashboard auto-loads under the Komputer folder in Grafana.
 The Prometheus container has `--web.enable-remote-write-receiver` enabled,
 so the agent can push directly to it.
 
+For a local kind cluster, the sample `KomputerAgentClusterTemplate` at
+`komputer-operator/config/samples/komputer_v1alpha1_komputeragentclustertemplate.yaml`
+already sets `KOMPUTER_METRICS_PER_AGENT=true` and points the agent at
+`http://host.docker.internal:9090/api/v1/write`. Just `kubectl apply` it
+(see [docs/local-development.md](../docs/local-development.md)) and every
+spawned agent will push to the local Prometheus.
+
+For a bare local agent process:
+
 ```bash
 export KOMPUTER_METRICS_REMOTE_WRITE_URL=http://localhost:9090/api/v1/write
 export KOMPUTER_METRICS_PER_AGENT=true
-# Then start an agent that uses these env vars (kind cluster, or local agent process).
 ```
 
 In Prometheus' web UI, query `komputer_agent_steering_total` etc.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,60 @@
+# Local monitoring stack
+
+Prometheus + Grafana for testing komputer-ai metrics locally.
+
+## Start
+
+```bash
+cd monitoring && docker compose up -d
+```
+
+- Prometheus: http://localhost:9090
+- Grafana: http://localhost:3000 (anonymous login as Admin, or admin/admin)
+
+The stack scrapes:
+- `komputer-api` on `host.docker.internal:8080/api/metrics` and `/agent/metrics`
+- `komputer-operator` on `host.docker.internal:8081/metrics`
+
+So run those locally before starting docker-compose:
+
+```bash
+# Terminal 1 — API
+cd komputer-api
+KOMPUTER_METRICS_PER_AGENT=true go run .
+
+# Terminal 2 — operator
+cd komputer-operator
+go run ./cmd/main.go --metrics-bind-address=:8081 --metrics-secure=false
+```
+
+The Komputer Overview dashboard auto-loads under the Komputer folder in Grafana.
+
+## Test agent remote-write
+
+The Prometheus container has `--web.enable-remote-write-receiver` enabled,
+so the agent can push directly to it.
+
+```bash
+export KOMPUTER_METRICS_REMOTE_WRITE_URL=http://localhost:9090/api/v1/write
+export KOMPUTER_METRICS_PER_AGENT=true
+# Then start an agent that uses these env vars (kind cluster, or local agent process).
+```
+
+In Prometheus' web UI, query `komputer_agent_steering_total` etc.
+
+## Linux note
+
+On Linux without Docker Desktop, `host.docker.internal` may not resolve.
+Either:
+
+```bash
+docker compose up -d --add-host=host.docker.internal:host-gateway
+```
+
+Or replace `host.docker.internal` with your actual host IP in `prometheus.yml`.
+
+## Stop
+
+```bash
+docker compose down -v
+```

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  prometheus:
+    image: prom/prometheus:v3.0.1
+    ports:
+      - "9090:9090"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-remote-write-receiver"  # needed for agent remote-write tests
+      - "--web.enable-lifecycle"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../helm/komputer-ai/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   grafana:
     image: grafana/grafana:11.4.0
     ports:
-      - "3000:3000"
+      - "3002:3000"
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: Komputer
+    folder: Komputer
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,25 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: komputer-api
+    metrics_path: /api/metrics
+    static_configs:
+      - targets:
+          # host.docker.internal works on Docker Desktop (Mac/Windows).
+          # Linux users without Docker Desktop need either:
+          # 1. Run docker compose with --add-host=host.docker.internal:host-gateway
+          # 2. Or replace this with the actual host IP
+          - host.docker.internal:8080
+
+  - job_name: komputer-agent-metrics
+    metrics_path: /agent/metrics
+    static_configs:
+      - targets:
+          - host.docker.internal:8080
+
+  - job_name: komputer-operator
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - host.docker.internal:8081

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -22,4 +22,4 @@ scrape_configs:
     metrics_path: /metrics
     static_configs:
       - targets:
-          - host.docker.internal:8081
+          - host.docker.internal:8082


### PR DESCRIPTION
## Summary

- Adds first-class Prometheus monitoring across the API, operator, and agent (Issue #37).
- Two endpoints on the API: `/api/metrics` (HTTP/WS/Redis plumbing) and `/agent/metrics` (worker-derived business metrics — task cost, tokens, duration, tool calls, agent actions, plus on-demand CR-list gauges for tasks-in-progress / schedules-active / agents-by-phase).
- Operator exposes `controller_runtime_*` metrics + a new `komputer_operator_template_cap_reached_total` counter on `:8082`.
- Agent pushes three metrics not visible in the event stream (steering, MCP connector health, subagent wait) via Prometheus remote-write — interval is configurable and per-agent labels are off by default to keep cardinality bounded.
- Helm chart ships ServiceMonitors for all three components, a Grafana dashboard ConfigMap (auto-discovered by kube-prometheus-stack), and now auto-injects all `KOMPUTER_METRICS_*` env vars into the default agent cluster template — no more manual env editing.
- `monitoring/` directory provides a one-command local stack (`docker compose up -d`) with Prometheus + Grafana, the dashboard auto-provisioned, and `--web.enable-remote-write-receiver` enabled so kind agents can push directly to it via `host.docker.internal:9090`.
- 26-panel Grafana dashboard with rate windows tuned per-panel (1m for high-frequency, 2m for sparse, 5m/10m for rare events and histograms).
- Comprehensive end-user docs in `docs/monitoring.md`.

## Test plan

- [ ] `helm template` renders without errors with metrics defaults
- [ ] `helm template` renders agent env vars when `metrics.agent.remoteWrite.enabled=true`
- [ ] Local stack: `cd monitoring && docker compose up -d` brings Prometheus + Grafana up
- [ ] Apply local sample template; spawn an agent; verify metrics appear in Prometheus and dashboard panels populate
- [ ] Confirm operator binds to `:8082` (no port collision with API on `:8080`)
- [ ] Verify cost-by-model panel shows model name (not "Value") after a task completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
