### PR TITLE
ci: fold docs-site deploy into the main build pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
       cli: ${{ steps.filter.outputs.cli }}
       helm: ${{ steps.filter.outputs.helm }}
       sdk: ${{ steps.filter.outputs.sdk }}
+      docs: ${{ steps.filter.outputs.docs }}
       is_tag: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +51,9 @@ jobs:
               - 'helm/**'
             sdk:
               - 'komputer-sdk/**'
+            docs:
+              - 'docs/**'
+              - 'docs-site/**'
 
   operator:
     name: Build Operator
@@ -325,6 +329,19 @@ jobs:
     secrets: inherit
     with:
       is_tag: ${{ needs.changes.outputs.is_tag }}
+
+  docs-site:
+    name: Docs Site
+    needs: [changes]
+    # Only deploy from main pushes — PRs run no checks here, tags are
+    # release artifacts handled separately.
+    if: needs.changes.outputs.docs == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/docs-site.yaml
+    secrets: inherit
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
 
   publish-sdk-python:
     name: Publish Python SDK

--- a/.github/workflows/docs-site.yaml
+++ b/.github/workflows/docs-site.yaml
@@ -1,12 +1,7 @@
-name: Deploy docs site
+name: Docs Site — Build & Deploy
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs-site/**'
-      - 'docs/**'
-      - '.github/workflows/docs-site.yaml'
+  workflow_call: {}
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Convert `docs-site.yaml` to a `workflow_call` target (kept `workflow_dispatch` for manual deploys).
- Add a `docs` paths filter to `build.yaml` covering `docs/**` and `docs-site/**`.
- New `docs-site` job in `build.yaml` calls the reusable workflow when docs changed AND it is a push to main.
- PRs and tag pushes skip the docs deploy (GitHub Pages publishes a single source; previews would be wasteful).

## Test plan

- [x] YAML validates locally.
- [ ] After merge: confirm a docs-only commit triggers the deploy job; a non-docs commit does not.
