### PR TITLE
feat(ui): light mode POC

### DIFF
--- a/komputer-ui/src/app/agents/[name]/page.tsx
+++ b/komputer-ui/src/app/agents/[name]/page.tsx
@@ -450,7 +450,7 @@ export default function AgentDetailPage() {
                     size="sm"
                     onClick={() => setViewAndUrl(view === "settings" ? "chat" : "settings")}
                     aria-label={view === "settings" ? "Back to chat" : "Settings"}
-                    className="!px-0 w-7 !bg-white !text-[var(--color-bg)] hover:!bg-white/90 border-white/20"
+                    className="!px-0 w-7 !bg-[var(--color-text)] !text-[var(--color-bg)] hover:!bg-[var(--color-text)]/90 border-[var(--color-text)]/20"
                   >
                     <AnimatePresence mode="wait" initial={false}>
                       <motion.span

--- a/komputer-ui/src/app/globals.css
+++ b/komputer-ui/src/app/globals.css
@@ -39,6 +39,15 @@
   --color-status-success: #34D399;
   --color-status-error: #F87171;
 
+  /*
+   * Outer shadow. On dark surfaces a black drop-shadow is invisible — we use
+   * a soft white outer glow instead. Light theme flips to a black drop-shadow.
+   */
+  --shadow-color: 255, 255, 255;
+  --shadow-strength: 0.06;
+  /* Inset / depth shadow — always darker than the surface, regardless of theme. */
+  --shadow-inset-color: 0, 0, 0;
+
   /* Radii — slightly less round, more industrial */
   --radius-sm: 6px;
   --radius-md: 10px;
@@ -47,9 +56,51 @@
   --radius-full: 9999px;
 }
 
+/*
+ * Light theme — opt-in via <html data-theme="light">.
+ * Overrides only the dark defaults above; everything else inherits.
+ * POC scope: dashboard page. Other pages will look weird; that is expected.
+ */
+:root[data-theme="light"] {
+  --color-brand-blue: #2d6cb8;
+  --color-brand-blue-light: #3f85d9;
+  --color-brand-blue-glow: rgba(45, 108, 184, 0.12);
+  --color-brand-blue-intense: rgba(45, 108, 184, 0.25);
+
+  --color-brand-violet: #6d3fc4;
+  --color-brand-violet-light: #8B5CF6;
+  --color-brand-violet-glow: rgba(109, 63, 196, 0.10);
+  --color-brand-violet-intense: rgba(109, 63, 196, 0.25);
+  --color-brand-violet-subtle: rgba(109, 63, 196, 0.06);
+
+  --color-bg: #fafaf7;
+  --color-bg-subtle: #f3f3ef;
+  --color-surface: #ffffff;
+  --color-surface-hover: #f3f3ef;
+  --color-surface-raised: #ffffff;
+  --color-border: #e2e2dc;
+  --color-border-hover: #c8c8c0;
+  --color-border-light: rgba(0, 0, 0, 0.04);
+
+  --color-text: #1a1a24;
+  --color-text-secondary: #5a5a70;
+  --color-text-muted: #8a8a9c;
+
+  --color-status-running: #059669;
+  --color-status-pending: #d97706;
+  --color-status-sleeping: #d97706;
+  --color-status-success: #059669;
+  --color-status-error: #dc2626;
+
+  /* Outer drop-shadow on light surfaces: neutral hue, soft. */
+  --shadow-color: 0, 0, 0;
+  --shadow-strength: 0.08;
+  --shadow-inset-color: 0, 0, 0;
+}
+
 @layer base {
   body {
-    background: radial-gradient(ellipse 80% 60% at 70% 20%, rgba(139, 92, 246, 0.04), transparent 70%) var(--color-bg);
+    background: var(--color-bg);
     color: var(--color-text);
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;

--- a/komputer-ui/src/app/page.tsx
+++ b/komputer-ui/src/app/page.tsx
@@ -77,7 +77,7 @@ function StatCard({
       transition={{ duration: 0.3, delay }}
       className="cursor-pointer"
     >
-      <Card className="bg-[var(--color-surface)] border-[var(--color-border)] ring-0 hover:shadow-[0_4px_16px_rgba(0,0,0,0.2),inset_0_1px_0_var(--color-border-light)] hover:border-[var(--color-border-hover)]">
+      <Card className="bg-[var(--color-surface)] border-[var(--color-border)] ring-0 hover:shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength)),inset_0_1px_0_var(--color-border-light)] hover:border-[var(--color-border-hover)]">
         <CardContent className="flex items-center gap-4 py-4">
           <div
             className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${iconClassName ?? "bg-[var(--color-brand-blue)]/10 text-[var(--color-brand-blue)]"}`}
@@ -212,7 +212,7 @@ export default function DashboardPage() {
           }}
         >
           <h1 className="text-xl font-semibold text-[var(--color-text)]">
-            Welcome to <span className="bg-gradient-to-r from-[#9ca3af] via-[#ffffff] to-[#9ca3af] bg-clip-text text-transparent animate-shine">Komputer.AI</span>
+            Welcome to <span className="bg-gradient-to-r from-[var(--color-text-secondary)] via-[var(--color-text)] to-[var(--color-text-secondary)] bg-clip-text text-transparent animate-shine">Komputer.AI</span>
           </h1>
           <p className="mt-1 text-sm text-[var(--color-text-secondary)]">
             Your AI agent fleet management at scale.
@@ -324,9 +324,7 @@ export default function DashboardPage() {
                   >
                     <Link href={`/agents/${agent.name}?namespace=${agent.namespace}`} className="block group">
                       <div
-                        className="relative overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] transition-all duration-200 group-hover:border-[var(--color-border-hover)]"
-                        onMouseEnter={(e) => { e.currentTarget.style.boxShadow = "0 0 12px rgba(255,255,255,0.06), 0 0 24px rgba(255,255,255,0.03)"; }}
-                        onMouseLeave={(e) => { e.currentTarget.style.boxShadow = "none"; }}
+                        className="relative overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] transition-all duration-200 group-hover:border-[var(--color-border-hover)] hover:shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength)),inset_0_1px_0_var(--color-border-light)]"
                       >
                         <span className="absolute top-2.5 right-2.5 block w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
                         <div className="h-full flex flex-col p-3">

--- a/komputer-ui/src/components/agents/agent-chat.tsx
+++ b/komputer-ui/src/components/agents/agent-chat.tsx
@@ -256,10 +256,13 @@ function TokenBadge({ usage }: { usage?: TokenUsage }) {
 function ContextBar({ inputTokens, contextWindow }: { inputTokens?: number; contextWindow: number }) {
   if (inputTokens == null || inputTokens === 0) return null;
   const pct = Math.min((inputTokens / contextWindow) * 100, 100);
+  // Hold the bar to the dark-theme palette in both modes — the brand blue
+  // here doubles as a fill on the muted track and stays legible without
+  // re-tuning per theme.
   const color =
-    pct >= 90 ? "var(--color-status-error)" :
-    pct >= 70 ? "var(--color-status-pending)" :
-    "var(--color-brand-blue)";
+    pct >= 90 ? "#F87171" :
+    pct >= 70 ? "#FBBF24" :
+    "#3f85d9";
   return (
     <div className="group relative h-[12px] cursor-default">
       {/* Bar sits 8px above the border edge */}
@@ -270,10 +273,10 @@ function ContextBar({ inputTokens, contextWindow }: { inputTokens?: number; cont
         />
       </div>
       <div className="pointer-events-none absolute bottom-full left-1/2 mb-4 -translate-x-1/2 z-20 whitespace-nowrap rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1.5 text-[11px] text-[var(--color-text-secondary)] opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100">
-        <span className="text-white">Context window</span>
+        <span className="text-[var(--color-text)]">Context window</span>
         {" · "}
         <span className="font-mono tabular-nums" style={{ color }}>{formatTokenCount(inputTokens)}</span>
-        <span className="text-white"> / {formatTokenCount(contextWindow)} tokens</span>
+        <span className="text-[var(--color-text)]"> / {formatTokenCount(contextWindow)} tokens</span>
       </div>
     </div>
   );
@@ -1273,7 +1276,7 @@ export function AgentChat({
             type="button"
             onClick={handleSend}
             disabled={!input.trim()}
-            className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-[var(--color-brand-blue)] text-white transition-opacity hover:opacity-80 disabled:opacity-30 disabled:cursor-not-allowed"
+            className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-[#3f85d9] text-white transition-opacity hover:opacity-80 disabled:opacity-30 disabled:cursor-not-allowed"
           >
             <ArrowUp className="size-4" />
           </button>

--- a/komputer-ui/src/components/dashboard/floating-bubbles.tsx
+++ b/komputer-ui/src/components/dashboard/floating-bubbles.tsx
@@ -241,7 +241,7 @@ export function FloatingBubbles({ session, onFirstResponse, onTaskComplete, onCl
     // bubbles cap their own height with internal scroll instead.
     <div
       ref={wrapperRef}
-      className="pointer-events-none absolute left-0 right-0 top-full z-30 mt-4 flex flex-col items-center gap-2"
+      className="pointer-events-none absolute left-0 right-0 top-full z-30 mt-12 flex flex-col items-center gap-2"
     >
       {/* Status bubble — thinking, then "Done ✓" with a one-shot glow pump.
           Wrapped in AnimatePresence so it gets a clean blur-slide-out when
@@ -300,7 +300,7 @@ export function FloatingBubbles({ session, onFirstResponse, onTaskComplete, onCl
                 handleClick();
               }
             }}
-            className="pointer-events-auto group relative flex w-fit max-w-[min(100%,40rem)] cursor-pointer items-start gap-2 rounded-2xl border border-[var(--color-border)]/60 bg-[var(--color-surface)]/40 px-3.5 py-2 text-left text-sm text-[var(--color-text)] shadow-[0_4px_24px_rgba(0,0,0,0.35)] backdrop-blur-md transition-colors hover:border-[var(--color-brand-blue)]/50 hover:bg-[var(--color-surface)]/60"
+            className="pointer-events-auto group relative flex w-fit max-w-[min(100%,40rem)] cursor-pointer items-start gap-2 rounded-2xl border border-[var(--color-border)]/60 bg-[var(--color-surface)]/40 px-3.5 py-2 text-left text-sm text-[var(--color-text)] shadow-[0_4px_24px_rgba(var(--shadow-color),var(--shadow-strength))] backdrop-blur-md transition-colors hover:border-[var(--color-brand-blue)]/50 hover:bg-[var(--color-surface)]/60"
           >
             <BubbleIcon kind={b.kind} />
             <BubbleBody
@@ -326,7 +326,7 @@ export function FloatingBubbles({ session, onFirstResponse, onTaskComplete, onCl
               e.stopPropagation();
               handleClearLocal();
             }}
-            className="pointer-events-auto inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-[var(--color-border)]/60 bg-[var(--color-surface)]/40 px-2.5 py-0.5 text-[11px] text-[var(--color-text-secondary)] shadow-[0_4px_16px_rgba(0,0,0,0.3)] backdrop-blur-md transition-colors hover:border-red-400/50 hover:text-red-300"
+            className="pointer-events-auto inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-[var(--color-border)]/60 bg-[var(--color-surface)]/40 px-2.5 py-0.5 text-[11px] text-[var(--color-text-secondary)] shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength))] backdrop-blur-md transition-colors hover:border-red-400/50 hover:text-red-300"
           >
             <X className="size-3" />
             Clear
@@ -359,7 +359,7 @@ function ToolActionsChip({ actions }: { actions: ToolAction[] }) {
     >
       <button
         type="button"
-        className="relative flex size-5 items-center justify-center overflow-hidden rounded-full border border-white/70 bg-[var(--color-surface-raised)] text-white shadow-[0_2px_8px_rgba(0,0,0,0.4)] transition-colors hover:border-white"
+        className="relative flex size-5 items-center justify-center overflow-hidden rounded-full border border-[var(--color-border-hover)] bg-[var(--color-surface-raised)] text-[var(--color-text)] shadow-[0_2px_8px_rgba(var(--shadow-color),var(--shadow-strength))] transition-colors hover:border-[var(--color-text)]"
         aria-label={`${actions.length} action${actions.length === 1 ? "" : "s"}`}
       >
         <AnimatePresence mode="popLayout" initial={false}>
@@ -370,7 +370,7 @@ function ToolActionsChip({ actions }: { actions: ToolAction[] }) {
             exit={{ y: -6, opacity: 0, filter: "blur(3px)" }}
             transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
             style={{ fontVariantNumeric: "tabular-nums" }}
-            className="text-[10px] font-semibold leading-none text-white"
+            className="text-[10px] font-semibold leading-none text-[var(--color-text)]"
           >
             {actions.length}
           </motion.span>
@@ -383,7 +383,7 @@ function ToolActionsChip({ actions }: { actions: ToolAction[] }) {
             animate={{ opacity: 1, x: 0, filter: "blur(0px)" }}
             exit={{ opacity: 0, x: -4, filter: "blur(4px)" }}
             transition={{ duration: 0.18, ease: "easeOut" }}
-            className="absolute bottom-1/2 left-1/2 ml-2 mb-2 w-72 rounded-xl border border-[var(--color-border)]/60 bg-[var(--color-surface-raised)] p-2 shadow-[0_8px_32px_rgba(0,0,0,0.5)]"
+            className="absolute bottom-1/2 left-1/2 ml-2 mb-2 w-72 rounded-xl border border-[var(--color-border)]/60 bg-[var(--color-surface-raised)] p-2 shadow-[0_8px_32px_rgba(var(--shadow-color),var(--shadow-strength))]"
             role="tooltip"
           >
             <div className="px-2 pb-1.5 pt-0.5 text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">
@@ -506,7 +506,7 @@ function StatusBubble({ done, onClick }: { done: boolean; onClick: () => void })
       animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
       transition={{ duration: 0.28, ease: "easeOut" }}
       onClick={onClick}
-      className={`pointer-events-auto inline-flex cursor-pointer items-center gap-2 rounded-full border bg-[var(--color-surface-raised)] px-3 py-1 text-xs text-[var(--color-text-secondary)] shadow-[0_4px_16px_rgba(0,0,0,0.4)] transition-colors hover:text-[var(--color-text)] ${
+      className={`pointer-events-auto inline-flex cursor-pointer items-center gap-2 rounded-full border bg-[var(--color-surface-raised)] px-3 py-1 text-xs text-[var(--color-text-secondary)] shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength))] transition-colors hover:text-[var(--color-text)] ${
         done
           ? "border-emerald-400/60 hover:border-emerald-300"
           : "border-[var(--color-border)] hover:border-[var(--color-brand-blue)]/50"

--- a/komputer-ui/src/components/dashboard/personal-agent-prompt.tsx
+++ b/komputer-ui/src/components/dashboard/personal-agent-prompt.tsx
@@ -424,7 +424,7 @@ export function PersonalAgentPrompt({ onSessionActiveChange }: PersonalAgentProm
             }}
             placeholder={session !== null ? "Enter another prompt for the agent..." : placeholder}
             rows={2}
-            className={`w-full resize-none min-h-[3.25rem] max-h-[7rem] rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3.5 py-2.5 text-sm leading-relaxed text-[var(--color-text)] placeholder:text-[var(--color-text-muted)] shadow-[inset_0_1px_2px_rgba(0,0,0,0.15)] transition-[border-color,background-color,box-shadow,height] duration-150 hover:border-[var(--color-border-hover)] hover:bg-[var(--color-surface-hover)] focus:border-[var(--color-brand-blue)]/60 focus:bg-[var(--color-surface)] focus:shadow-[inset_0_1px_2px_rgba(0,0,0,0.15),0_0_0_3px_rgba(63,133,217,0.15)] focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed${blurInToken > 0 ? " animate-text-blur-in" : ""}`}
+            className={`w-full resize-none min-h-[3.25rem] max-h-[7rem] rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3.5 py-2.5 text-sm leading-relaxed text-[var(--color-text)] placeholder:text-[var(--color-text-muted)] shadow-[inset_0_1px_2px_rgba(var(--shadow-inset-color),0.15)] transition-[border-color,background-color,box-shadow,height] duration-150 hover:border-[var(--color-border-hover)] hover:bg-[var(--color-surface-hover)] focus:border-[var(--color-brand-blue)]/60 focus:bg-[var(--color-surface)] focus:shadow-[inset_0_1px_2px_rgba(var(--shadow-inset-color),0.15),0_0_0_3px_var(--color-brand-blue-glow)] focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed${blurInToken > 0 ? " animate-text-blur-in" : ""}`}
             disabled={submitting}
           />
           <Button

--- a/komputer-ui/src/components/layout/sidebar.tsx
+++ b/komputer-ui/src/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
+import { ThemeToggle } from "./theme-toggle";
 import {
   LayoutDashboard,
   Bot,
@@ -204,8 +205,9 @@ export function Sidebar() {
           ))}
         </nav>
 
-        {/* Bottom: settings + expand button (when collapsed) */}
+        {/* Bottom: theme toggle + settings + expand button (when collapsed) */}
         <div className="border-t border-[var(--color-border)] px-2 py-2 flex flex-col gap-0.5">
+          <ThemeToggle collapsed={collapsed} />
           {bottomItems.map((item) => (
             <NavItem
               key={item.href}

--- a/komputer-ui/src/components/layout/theme-toggle.tsx
+++ b/komputer-ui/src/components/layout/theme-toggle.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { motion } from "framer-motion";
+
+const STORAGE_KEY = "komputer-theme";
+
+type Theme = "dark" | "light";
+
+/**
+ * Sidebar-friendly theme toggle. Flips `data-theme` on <html> and persists
+ * to localStorage. Visual treatment matches the sidebar's nav rows so it
+ * sits naturally in the bottom region.
+ */
+export function ThemeToggle({ collapsed }: { collapsed: boolean }) {
+  const [theme, setTheme] = useState<Theme>("dark");
+
+  useEffect(() => {
+    const stored = (typeof window !== "undefined" && window.localStorage.getItem(STORAGE_KEY)) as Theme | null;
+    const initial: Theme = stored === "light" ? "light" : "dark";
+    setTheme(initial);
+    apply(initial);
+  }, []);
+
+  function toggle() {
+    const next: Theme = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    apply(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // ignore quota / private-mode errors
+    }
+  }
+
+  const Icon = theme === "dark" ? Sun : Moon;
+  const label = theme === "dark" ? "Light mode" : "Dark mode";
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={label}
+      className="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium font-[family-name:var(--font-sans)] text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-surface)] transition-all duration-200 relative overflow-hidden cursor-pointer"
+    >
+      <Icon className="h-5 w-5 shrink-0" />
+      {!collapsed && (
+        <motion.span
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          {label}
+        </motion.span>
+      )}
+    </button>
+  );
+}
+
+function apply(theme: Theme) {
+  if (typeof document === "undefined") return;
+  if (theme === "light") {
+    document.documentElement.setAttribute("data-theme", "light");
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
+}

--- a/komputer-ui/src/components/topology/node-types.tsx
+++ b/komputer-ui/src/components/topology/node-types.tsx
@@ -88,7 +88,7 @@ function AgentNodeComponent({ data }: NodeProps) {
 
   return (
     <div
-      className={`relative cursor-pointer rounded-lg border px-4 py-3 shadow-md transition-shadow hover:shadow-lg ${
+      className={`relative cursor-pointer rounded-lg border px-4 py-3 transition-shadow hover:shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength)),inset_0_1px_0_var(--color-border-light)] ${
         isDeleted
           ? "border-red-400/30 bg-red-400/5 opacity-60"
           : "border-[var(--color-border)] bg-[var(--color-surface)]"
@@ -117,7 +117,7 @@ function AgentNodeComponent({ data }: NodeProps) {
       <Handle type="source" position={Position.Bottom} className={hasOutgoing ? handleVisible : handleHidden} />
 
       {hovered && !isDeleted && (
-        <div className="absolute left-full top-0 ml-3 z-50 min-w-52 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] p-3 shadow-[0_8px_32px_rgba(0,0,0,0.4)] pointer-events-none animate-[tooltipIn_0.15s_ease-out]">
+        <div className="absolute left-full top-0 ml-3 z-50 min-w-52 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] p-3 shadow-[0_8px_32px_rgba(var(--shadow-color),var(--shadow-strength))] pointer-events-none animate-[tooltipIn_0.15s_ease-out]">
           <TooltipHeader
             icon={<span className={`inline-block h-2.5 w-2.5 rounded-full ${statusDotClass(status)}`} />}
             title={label}
@@ -161,7 +161,7 @@ function OfficeNodeComponent({ data }: NodeProps) {
 
   return (
     <div
-      className="relative cursor-pointer rounded-lg border border-[var(--color-border)] bg-[#1e2d3d] px-5 py-3.5 shadow-md transition-shadow hover:shadow-lg"
+      className="relative cursor-pointer rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-5 py-3.5 transition-shadow hover:shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength)),inset_0_1px_0_var(--color-border-light)]"
       style={{ width: nodeWidth || 220 }}
       data-hovered={hovered || undefined}
       onClick={() => router.push(`/offices/${label}`)}
@@ -187,7 +187,7 @@ function OfficeNodeComponent({ data }: NodeProps) {
       <Handle type="source" position={Position.Bottom} className={hasOutgoing ? handleVisible : handleHidden} />
 
       {hovered && (
-        <div className="absolute left-full top-0 ml-3 z-50 min-w-52 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] p-3 shadow-[0_8px_32px_rgba(0,0,0,0.4)] pointer-events-none animate-[tooltipIn_0.15s_ease-out]">
+        <div className="absolute left-full top-0 ml-3 z-50 min-w-52 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] p-3 shadow-[0_8px_32px_rgba(var(--shadow-color),var(--shadow-strength))] pointer-events-none animate-[tooltipIn_0.15s_ease-out]">
           <TooltipHeader
             icon={<Building2 className="h-3.5 w-3.5 text-[var(--color-brand-blue)]" />}
             title={label}
@@ -256,7 +256,7 @@ function ScheduleNodeComponent({ data }: NodeProps) {
       <Handle type="source" position={Position.Bottom} className={hasOutgoing ? handleVisible : handleHidden} />
 
       {hovered && (
-        <div className="absolute left-full top-0 ml-3 z-50 min-w-52 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] p-3 shadow-[0_8px_32px_rgba(0,0,0,0.4)] pointer-events-none animate-[tooltipIn_0.15s_ease-out]">
+        <div className="absolute left-full top-0 ml-3 z-50 min-w-52 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] p-3 shadow-[0_8px_32px_rgba(var(--shadow-color),var(--shadow-strength))] pointer-events-none animate-[tooltipIn_0.15s_ease-out]">
           <TooltipHeader
             icon={<Clock className="h-3.5 w-3.5 text-cyan-400" />}
             title={label}


### PR DESCRIPTION
## Summary

Opt-in light theme via `:root[data-theme="light"]` overrides on the existing design tokens. Toggle lives at the bottom of the sidebar; persists in localStorage.

- Light palette tuned for warm off-white surfaces and brand colors darkened ~25% for contrast on a light bg.
- New theme-aware outer-shadow tokens (`--shadow-color` / `--shadow-strength`) so hover shadows render as a soft white glow on dark and a subtle drop-shadow on light.
- Hardcoded dark-only bits cleaned up: topology office bg, agent detail Settings button, dashboard card hover, prompt textarea inset shadow.
- A few elements (context-window bar, send button) deliberately keep the dark-theme blue in both themes for visual identity.

Scope is a POC — most pages render correctly in light, but a follow-up sweep will catch any remaining dark-only spots outside the dashboard / agent detail / topology paths.

## Test plan

- [x] Toggle persists across reload via `localStorage["komputer-theme"]`.
- [x] Dashboard, agent detail, topology, sidebar render correctly in both themes.
- [ ] Walk other pages (offices, secrets, connectors, schedules, memories, skills) and report any visual regressions.
