### PR TITLE
fix(operator): inject ANTHROPIC_API_KEY into squad members + close solo/squad pod race

### DIFF
--- a/komputer-operator/internal/controller/komputeragent_controller.go
+++ b/komputer-operator/internal/controller/komputeragent_controller.go
@@ -100,10 +100,22 @@ func (r *KomputerAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// Skip agents owned by a squad — the squad controller is responsible for their lifecycle.
-	// Defensive: if Status.Squad=true but no parent squad exists (e.g. squad was deleted while
-	// the operator was down and finalizer cleanup didn't run), reclaim the agent as solo so it
-	// doesn't sit orphaned forever.
+	// Squad-managed agents: the squad controller owns their pod lifecycle.
+	// We use the `komputer.ai/squad` label as the race-free signal — it is
+	// written atomically when the squad controller Creates the agent CR, so
+	// the agent controller sees it on its very first reconcile and never
+	// builds a competing solo pod. Status.Squad is a derived field; checking
+	// it alone would race because Status updates require a separate
+	// subresource call after Create.
+	if agent.Labels["komputer.ai/squad"] != "" {
+		return ctrl.Result{}, nil
+	}
+
+	// Defensive fallback: if Status.Squad=true but no parent squad exists
+	// (e.g. squad was deleted while the operator was down and finalizer
+	// cleanup didn't run), reclaim the agent as solo so it doesn't sit
+	// orphaned forever. This path is unreachable under the new label guard
+	// above for healthy squads, but stays in place as a recovery net.
 	if agent.Status.Squad {
 		squadList := &komputerv1alpha1.KomputerSquadList{}
 		if listErr := r.List(ctx, squadList, client.InNamespace(agent.Namespace)); listErr == nil {

--- a/komputer-operator/internal/controller/komputersquad_controller.go
+++ b/komputer-operator/internal/controller/komputersquad_controller.go
@@ -806,6 +806,23 @@ func (r *KomputerSquadReconciler) buildSquadPodSpec(ctx context.Context, squad *
 		if agent.Status.Phase == komputerv1alpha1.AgentPhaseSleeping {
 			envVars = append(envVars, corev1.EnvVar{Name: "KOMPUTER_WAKE_IDLE", Value: "true"})
 		}
+		// Inject ANTHROPIC_API_KEY from the template's AnthropicKeySecretRef.
+		// The mirror exists in the squad pod's namespace, so the secretKeyRef
+		// resolves locally. Mirrors are reconciled the same way solo agents do.
+		envVars = append(envVars, corev1.EnvVar{
+			Name: "ANTHROPIC_API_KEY",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: template.Spec.AnthropicKeySecretRef.Name,
+					},
+					Key: template.Spec.AnthropicKeySecretRef.Key,
+				},
+			},
+		})
+		// Strip any user-supplied ANTHROPIC_API_KEY from the template before
+		// merging so the operator-injected entry above always wins.
+		c.Env = stripEnvVar(c.Env, "ANTHROPIC_API_KEY", logf.FromContext(ctx))
 		c.Env = mergeEnvVars(c.Env, envVars)
 
 		// Declare the per-member containerPort. Name must be unique across the


### PR DESCRIPTION
## Summary

Two operator fixes surfaced after v0.15.1.

**Squad pod env injection.** The agent controller injects `ANTHROPIC_API_KEY` into the solo pod from `template.AnthropicKeySecretRef` and strips any user-supplied entry. The squad controller, which builds its own multi-container pod by deep-copying the template container per member, never did the equivalent — so squad members started without an API key once the helm-shipped cluster template stopped carrying the inline env entry. Apply the same inject + strip inside the squad controller member loop.

**Solo / squad pod race.** When a squad created its member CRs, the agent controller could see the new agent CR via informer before the squad controller had set `status.squad=true`, build a solo pod, and end up with two pods for the same agent (`alpha-coder-pod` alongside `alpha-squad-pod`). Gate the agent controller on the `komputer.ai/squad` label, which the squad controller writes atomically at Create — labels persist through Create, status fields require a separate subresource update and therefore race. The Status.Squad-based reclaim path stays as a defensive recovery net.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./internal/controller/...` passes.
- [ ] Verified locally: a fresh squad creates exactly one squad pod, no orphan solo pods. Squad members get `ANTHROPIC_API_KEY` from the typed ref.
