### PR TITLE
feat(ui): dashboard cards expansion + light-mode polish

### DIFF
--- a/komputer-ui/src/app/page.tsx
+++ b/komputer-ui/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { useDelayedLoading } from "@/hooks/use-delayed-loading";
@@ -10,13 +10,43 @@ import {
   DollarSign,
   Building2,
   CalendarClock,
+  Wrench,
+  Brain,
+  KeyRound,
+  Plug,
+  Users,
   ArrowRight,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 
 import { Card, CardContent } from "@/components/kit/card";
-import { listAgents, listOffices, listSchedules } from "@/lib/api";
+import {
+  listAgents,
+  listOffices,
+  listSchedules,
+  listSkills,
+  listMemories,
+  listSecrets,
+  listConnectors,
+  listSquads,
+} from "@/lib/api";
 import { formatCost, formatRelativeTime } from "@/lib/utils";
-import type { AgentResponse, OfficeResponse, ScheduleResponse } from "@/lib/types";
+import type {
+  AgentResponse,
+  OfficeResponse,
+  ScheduleResponse,
+  SkillResponse,
+  MemoryResponse,
+  SecretResponse,
+  ConnectorResponse,
+  Squad,
+  SkillListResponse,
+  MemoryListResponse,
+  SecretListResponse,
+  ConnectorListResponse,
+  SquadListResponse,
+} from "@/lib/types";
 import { SuggestedTasks } from "@/components/dashboard/suggested-tasks";
 import { PersonalAgentPrompt } from "@/components/dashboard/personal-agent-prompt";
 
@@ -61,6 +91,7 @@ function StatCard({
   delay = 0,
   iconClassName,
   breakdown,
+  href,
 }: {
   icon: React.ReactNode;
   label: string;
@@ -68,45 +99,137 @@ function StatCard({
   delay?: number;
   iconClassName?: string;
   breakdown?: { color: string; count: number; label: string }[];
+  href?: string;
 }) {
+  const inner = (
+    <Card className="bg-[var(--color-surface)] border-[var(--color-border)] ring-0 hover:shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength)),inset_0_1px_0_var(--color-border-light)] hover:border-[var(--color-border-hover)]">
+      <CardContent className="flex items-center gap-4 py-4">
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${iconClassName ?? "bg-[var(--color-brand-blue)]/10 text-[var(--color-brand-blue)]"}`}
+        >
+          {icon}
+        </div>
+        <div className="min-w-0">
+          <p className="text-xs text-[var(--color-text-secondary)]">{label}</p>
+          <div className="flex items-baseline gap-3">
+            <p className="text-2xl font-semibold text-[var(--color-text)] tabular-nums">
+              <AnimatedNumber value={value} />
+            </p>
+            {breakdown && breakdown.some((b) => b.count > 0) && (
+              <div className="flex flex-wrap gap-x-2 gap-y-0.5">
+                {breakdown.map((b) =>
+                  b.count > 0 ? (
+                    <span key={b.label} className="inline-flex items-center gap-1 text-xs text-[var(--color-text)]">
+                      <span className="size-1.5 rounded-full" style={{ backgroundColor: b.color }} />
+                      {b.count} {b.label}
+                    </span>
+                  ) : null
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       whileHover={{ y: -2, transition: { duration: 0.15 } }}
       transition={{ duration: 0.3, delay }}
-      className="cursor-pointer"
+      className={`cursor-pointer w-[260px] shrink-0 ${href ? "" : ""}`}
     >
-      <Card className="bg-[var(--color-surface)] border-[var(--color-border)] ring-0 hover:shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength)),inset_0_1px_0_var(--color-border-light)] hover:border-[var(--color-border-hover)]">
-        <CardContent className="flex items-center gap-4 py-4">
-          <div
-            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${iconClassName ?? "bg-[var(--color-brand-blue)]/10 text-[var(--color-brand-blue)]"}`}
-          >
-            {icon}
-          </div>
-          <div className="min-w-0">
-            <p className="text-xs text-[var(--color-text-secondary)]">{label}</p>
-            <div className="flex items-baseline gap-3">
-              <p className="text-2xl font-semibold text-[var(--color-text)] tabular-nums">
-                <AnimatedNumber value={value} />
-              </p>
-              {breakdown && breakdown.some((b) => b.count > 0) && (
-                <div className="flex flex-wrap gap-x-2 gap-y-0.5">
-                  {breakdown.map((b) =>
-                    b.count > 0 ? (
-                      <span key={b.label} className="inline-flex items-center gap-1 text-xs text-[var(--color-text)]">
-                        <span className="size-1.5 rounded-full" style={{ backgroundColor: b.color }} />
-                        {b.count} {b.label}
-                      </span>
-                    ) : null
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      {href ? <Link href={href}>{inner}</Link> : inner}
     </motion.div>
+  );
+}
+
+// --- Scrollable stats row ---
+
+function StatsScrollRow({ children }: { children: React.ReactNode }) {
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [showLeft, setShowLeft] = useState(false);
+  const [showRight, setShowRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = rowRef.current;
+    if (!el) return;
+    setShowLeft(el.scrollLeft > 4);
+    setShowRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
+  }, []);
+
+  useEffect(() => {
+    const el = rowRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    const ro = new ResizeObserver(updateScrollState);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      ro.disconnect();
+    };
+  }, [updateScrollState]);
+
+  const scrollBy = (direction: "left" | "right") => {
+    const el = rowRef.current;
+    if (!el) return;
+    const delta = direction === "right" ? 280 : -280;
+    const target = Math.max(0, Math.min(el.scrollWidth - el.clientWidth, el.scrollLeft + delta));
+    el.scrollTo({ left: target, behavior: "smooth" });
+  };
+
+  return (
+    <div className="relative min-w-0">
+      {/* Left fade + chevron */}
+      {showLeft && (
+        <>
+          <div
+            className="pointer-events-none absolute left-0 top-0 bottom-0 w-8 z-10"
+            style={{
+              background: "linear-gradient(to right, var(--color-bg), transparent)",
+            }}
+          />
+          <button
+            onClick={() => scrollBy("left")}
+            className="absolute left-1 top-1/2 -translate-y-1/2 z-20 flex h-7 w-7 items-center justify-center rounded-full bg-[var(--color-surface-raised)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text)] shadow-sm transition-colors"
+            aria-label="Scroll left"
+          >
+            <ChevronLeft className="size-3.5" />
+          </button>
+        </>
+      )}
+
+      {/* Right fade + chevron */}
+      {showRight && (
+        <>
+          <div
+            className="pointer-events-none absolute right-0 top-0 bottom-0 w-8 z-10"
+            style={{
+              background: "linear-gradient(to left, var(--color-bg), transparent)",
+            }}
+          />
+          <button
+            onClick={() => scrollBy("right")}
+            className="absolute right-1 top-1/2 -translate-y-1/2 z-20 flex h-7 w-7 items-center justify-center rounded-full bg-[var(--color-surface-raised)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text)] shadow-sm transition-colors"
+            aria-label="Scroll right"
+          >
+            <ChevronRight className="size-3.5" />
+          </button>
+        </>
+      )}
+
+      <div
+        ref={rowRef}
+        className="flex gap-4 overflow-x-auto pb-1"
+        style={{ scrollbarWidth: "none" }}
+      >
+        <style>{`.stats-row::-webkit-scrollbar { display: none; }`}</style>
+        {children}
+      </div>
+    </div>
   );
 }
 
@@ -116,6 +239,11 @@ export default function DashboardPage() {
   const [agents, setAgents] = useState<AgentResponse[]>([]);
   const [offices, setOffices] = useState<OfficeResponse[]>([]);
   const [schedules, setSchedules] = useState<ScheduleResponse[]>([]);
+  const [skills, setSkills] = useState<SkillResponse[]>([]);
+  const [memories, setMemories] = useState<MemoryResponse[]>([]);
+  const [secrets, setSecrets] = useState<SecretResponse[]>([]);
+  const [connectors, setConnectors] = useState<ConnectorResponse[]>([]);
+  const [squads, setSquads] = useState<Squad[]>([]);
   const [loading, setLoading] = useState(true);
   const showLoading = useDelayedLoading(loading);
   // True while the prompt bar has an active streaming session — used to
@@ -124,14 +252,25 @@ export default function DashboardPage() {
 
   const fetchData = useCallback(async () => {
     try {
-      const [agentsRes, officesRes, schedulesRes] = await Promise.all([
-        listAgents(),
-        listOffices(),
-        listSchedules(),
-      ]);
+      const [agentsRes, officesRes, schedulesRes, skillsRes, memoriesRes, secretsRes, connectorsRes, squadsRes] =
+        await Promise.all([
+          listAgents(),
+          listOffices(),
+          listSchedules(),
+          listSkills().catch(() => ({ skills: [] })),
+          listMemories().catch(() => ({ memories: [] })),
+          listSecrets().catch(() => ({ secrets: [] })),
+          listConnectors().catch(() => ({ connectors: [] })),
+          listSquads().catch(() => ({ squads: [] })),
+        ]);
       setAgents(agentsRes.agents ?? []);
       setOffices(officesRes.offices ?? []);
       setSchedules(schedulesRes.schedules ?? []);
+      setSkills((skillsRes as SkillListResponse).skills ?? []);
+      setMemories((memoriesRes as MemoryListResponse).memories ?? []);
+      setSecrets((secretsRes as SecretListResponse).secrets ?? []);
+      setConnectors((connectorsRes as ConnectorListResponse).connectors ?? []);
+      setSquads((squadsRes as SquadListResponse).squads ?? []);
     } catch {
       // silently fail
     } finally {
@@ -172,6 +311,21 @@ export default function DashboardPage() {
     Active: schedules.filter((s) => s.phase === "Active").length,
     Suspended: schedules.filter((s) => s.phase === "Suspended").length,
     Error: schedules.filter((s) => s.phase === "Error").length,
+  };
+
+  // Connector OAuth breakdown
+  const oauthConnectors = connectors.filter((c) => c.authType === "oauth" && c.oauthStatus);
+  const connectorsByOAuth = {
+    connected: oauthConnectors.filter((c) => c.oauthStatus === "connected").length,
+    pending: oauthConnectors.filter((c) => c.oauthStatus === "pending").length,
+  };
+
+  // Squad phase breakdown
+  const squadsByPhase = {
+    Running: squads.filter((s) => s.phase === "Running").length,
+    Pending: squads.filter((s) => s.phase === "Pending").length,
+    Orphaned: squads.filter((s) => s.phase === "Orphaned").length,
+    Failed: squads.filter((s) => s.phase === "Failed").length,
   };
 
   // Running tasks (agents with InProgress task)
@@ -235,13 +389,14 @@ export default function DashboardPage() {
           }}
         >
 
-        {/* Stats row */}
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {/* Stats row — horizontally scrollable */}
+        <StatsScrollRow>
           <StatCard
             icon={<Bot className="size-5" />}
             label="Total Agents"
             value={agents.length}
             delay={0}
+            href="/agents"
             breakdown={[
               { color: "#34D399", count: agentsByStatus.Running, label: "Running" },
               { color: "#FBBF24", count: agentsByStatus.Sleeping, label: "Sleeping" },
@@ -254,14 +409,15 @@ export default function DashboardPage() {
             icon={<DollarSign className="size-5" />}
             label="Total Cost"
             value={totalCost}
-            delay={0.05}
+            delay={0.04}
             iconClassName="bg-[var(--color-brand-violet)]/10 text-[var(--color-brand-violet)]"
           />
           <StatCard
             icon={<Building2 className="size-5" />}
             label="Offices"
             value={offices.length}
-            delay={0.1}
+            delay={0.08}
+            href="/offices"
             breakdown={[
               { color: "#34D399", count: officesByPhase.InProgress, label: "In Progress" },
               { color: "#34D399", count: officesByPhase.Complete, label: "Complete" },
@@ -272,7 +428,8 @@ export default function DashboardPage() {
             icon={<CalendarClock className="size-5" />}
             label="Schedules"
             value={schedules.length}
-            delay={0.15}
+            delay={0.12}
+            href="/schedules"
             iconClassName="bg-[var(--color-brand-violet)]/10 text-[var(--color-brand-violet)]"
             breakdown={[
               { color: "#34D399", count: schedulesByPhase.Active, label: "Active" },
@@ -280,7 +437,54 @@ export default function DashboardPage() {
               { color: "#F87171", count: schedulesByPhase.Error, label: "Error" },
             ]}
           />
-        </div>
+          <StatCard
+            icon={<Wrench className="size-5" />}
+            label="Skills"
+            value={skills.length}
+            delay={0.16}
+            href="/skills"
+          />
+          <StatCard
+            icon={<Brain className="size-5" />}
+            label="Memories"
+            value={memories.length}
+            delay={0.20}
+            href="/memories"
+            iconClassName="bg-[var(--color-brand-violet)]/10 text-[var(--color-brand-violet)]"
+          />
+          <StatCard
+            icon={<KeyRound className="size-5" />}
+            label="Secrets"
+            value={secrets.length}
+            delay={0.24}
+            href="/secrets"
+          />
+          <StatCard
+            icon={<Plug className="size-5" />}
+            label="Connectors"
+            value={connectors.length}
+            delay={0.28}
+            href="/connectors"
+            iconClassName="bg-[var(--color-brand-violet)]/10 text-[var(--color-brand-violet)]"
+            breakdown={[
+              { color: "#34D399", count: connectorsByOAuth.connected, label: "Connected" },
+              { color: "#FBBF24", count: connectorsByOAuth.pending, label: "Pending" },
+            ]}
+          />
+          <StatCard
+            icon={<Users className="size-5" />}
+            label="Squads"
+            value={squads.length}
+            delay={0.32}
+            href="/squads"
+            breakdown={[
+              { color: "#34D399", count: squadsByPhase.Running, label: "Running" },
+              { color: "#FBBF24", count: squadsByPhase.Pending, label: "Pending" },
+              { color: "#F87171", count: squadsByPhase.Orphaned, label: "Orphaned" },
+              { color: "#F87171", count: squadsByPhase.Failed, label: "Failed" },
+            ]}
+          />
+        </StatsScrollRow>
 
         {/* Suggested Tasks (above when empty) */}
         {!loading && agents.length === 0 && <SuggestedTasks />}

--- a/komputer-ui/src/app/page.tsx
+++ b/komputer-ui/src/app/page.tsx
@@ -102,8 +102,8 @@ function StatCard({
   href?: string;
 }) {
   const inner = (
-    <Card className="bg-[var(--color-surface)] border-[var(--color-border)] ring-0 hover:shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength)),inset_0_1px_0_var(--color-border-light)] hover:border-[var(--color-border-hover)]">
-      <CardContent className="flex items-center gap-4 py-4">
+    <Card className="h-[88px] bg-[var(--color-surface)] border-[var(--color-border)] ring-0 hover:shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength)),inset_0_1px_0_var(--color-border-light)] hover:border-[var(--color-border-hover)]">
+      <CardContent className="flex h-full items-center gap-4 py-4">
         <div
           className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${iconClassName ?? "bg-[var(--color-brand-blue)]/10 text-[var(--color-brand-blue)]"}`}
         >
@@ -111,16 +111,16 @@ function StatCard({
         </div>
         <div className="min-w-0">
           <p className="text-xs text-[var(--color-text-secondary)]">{label}</p>
-          <div className="flex items-baseline gap-3">
-            <p className="text-2xl font-semibold text-[var(--color-text)] tabular-nums">
+          <div className="flex items-baseline gap-3 min-w-0">
+            <p className="text-2xl font-semibold text-[var(--color-text)] tabular-nums shrink-0">
               <AnimatedNumber value={value} />
             </p>
             {breakdown && breakdown.some((b) => b.count > 0) && (
-              <div className="flex flex-wrap gap-x-2 gap-y-0.5">
+              <div className="flex items-center gap-x-2 overflow-hidden">
                 {breakdown.map((b) =>
                   b.count > 0 ? (
-                    <span key={b.label} className="inline-flex items-center gap-1 text-xs text-[var(--color-text)]">
-                      <span className="size-1.5 rounded-full" style={{ backgroundColor: b.color }} />
+                    <span key={b.label} className="inline-flex items-center gap-1 text-xs text-[var(--color-text)] whitespace-nowrap">
+                      <span className="size-1.5 rounded-full shrink-0" style={{ backgroundColor: b.color }} />
                       {b.count} {b.label}
                     </span>
                   ) : null
@@ -139,7 +139,7 @@ function StatCard({
       animate={{ opacity: 1, y: 0 }}
       whileHover={{ y: -2, transition: { duration: 0.15 } }}
       transition={{ duration: 0.3, delay }}
-      className={`cursor-pointer w-[260px] shrink-0 ${href ? "" : ""}`}
+      className={`cursor-pointer shrink-0 w-[calc((100%-48px)/4)] min-w-[220px]`}
     >
       {href ? <Link href={href}>{inner}</Link> : inner}
     </motion.div>
@@ -182,7 +182,10 @@ function StatsScrollRow({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <div className="relative min-w-0">
+    // -mb-2 cancels half of the row's pb-6 in the outer space-y-6 stack so
+    // the visual gap to the next section stays comfortable while the row
+    // still reserves room internally for hover-shadow render below the cards.
+    <div className="relative min-w-0 -mb-2">
       {/* Left fade + chevron */}
       {showLeft && (
         <>
@@ -223,7 +226,7 @@ function StatsScrollRow({ children }: { children: React.ReactNode }) {
 
       <div
         ref={rowRef}
-        className="flex gap-4 overflow-x-auto pb-1"
+        className="flex gap-4 overflow-x-auto pt-2 pb-6"
         style={{ scrollbarWidth: "none" }}
       >
         <style>{`.stats-row::-webkit-scrollbar { display: none; }`}</style>
@@ -438,28 +441,6 @@ export default function DashboardPage() {
             ]}
           />
           <StatCard
-            icon={<Wrench className="size-5" />}
-            label="Skills"
-            value={skills.length}
-            delay={0.16}
-            href="/skills"
-          />
-          <StatCard
-            icon={<Brain className="size-5" />}
-            label="Memories"
-            value={memories.length}
-            delay={0.20}
-            href="/memories"
-            iconClassName="bg-[var(--color-brand-violet)]/10 text-[var(--color-brand-violet)]"
-          />
-          <StatCard
-            icon={<KeyRound className="size-5" />}
-            label="Secrets"
-            value={secrets.length}
-            delay={0.24}
-            href="/secrets"
-          />
-          <StatCard
             icon={<Plug className="size-5" />}
             label="Connectors"
             value={connectors.length}
@@ -483,6 +464,28 @@ export default function DashboardPage() {
               { color: "#F87171", count: squadsByPhase.Orphaned, label: "Orphaned" },
               { color: "#F87171", count: squadsByPhase.Failed, label: "Failed" },
             ]}
+          />
+          <StatCard
+            icon={<Wrench className="size-5" />}
+            label="Skills"
+            value={skills.length}
+            delay={0.16}
+            href="/skills"
+          />
+          <StatCard
+            icon={<Brain className="size-5" />}
+            label="Memories"
+            value={memories.length}
+            delay={0.20}
+            href="/memories"
+            iconClassName="bg-[var(--color-brand-violet)]/10 text-[var(--color-brand-violet)]"
+          />
+          <StatCard
+            icon={<KeyRound className="size-5" />}
+            label="Secrets"
+            value={secrets.length}
+            delay={0.24}
+            href="/secrets"
           />
         </StatsScrollRow>
 

--- a/komputer-ui/src/components/agents/agent-fields-form.tsx
+++ b/komputer-ui/src/components/agents/agent-fields-form.tsx
@@ -15,6 +15,8 @@ import {
 import { MultiSelect, type MultiSelectOption } from "@/components/kit/multi-select";
 import { ChevronRight, Plus } from "lucide-react";
 import { CreateSecretModal } from "@/components/secrets/create-secret-modal";
+import { ConnectorLogo } from "@/components/connectors/connector-logo";
+import { useConnectorTemplates } from "@/hooks/use-connector-templates";
 import { NamespaceSelector } from "@/components/shared/namespace-selector";
 import { listTemplates, listMemories, listSkills, listSecrets, listConnectors } from "@/lib/api";
 import type { TemplateResponse } from "@/lib/types";
@@ -94,10 +96,12 @@ export function AgentFieldsForm({
   const advancedRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  const { getByService: getConnectorTemplate } = useConnectorTemplates();
+
   const [templates, setTemplates] = useState<TemplateResponse[]>([]);
   const [availableMemories, setAvailableMemories] = useState<{ name: string; namespace: string; ref: string }[]>([]);
   const [availableSkills, setAvailableSkills] = useState<{ name: string; namespace: string; ref: string }[]>([]);
-  const [availableConnectors, setAvailableConnectors] = useState<{ name: string; namespace: string; ref: string }[]>([]);
+  const [availableConnectors, setAvailableConnectors] = useState<{ name: string; namespace: string; ref: string; service: string }[]>([]);
   const [availableSecrets, setAvailableSecrets] = useState<{ name: string; namespace: string }[]>([]);
   const [createSecretOpen, setCreateSecretOpen] = useState(false);
 
@@ -130,6 +134,7 @@ export function AgentFieldsForm({
         name: c.name,
         namespace: c.namespace,
         ref: c.namespace === (namespace || "default") ? c.name : `${c.namespace}/${c.name}`,
+        service: c.service,
       }))))
       .catch(() => setAvailableConnectors([]));
   }, [active, namespace, showAllSecrets]);
@@ -343,12 +348,18 @@ export function AgentFieldsForm({
                   <div className="flex flex-col gap-1.5">
                     <Label>Connectors</Label>
                     <MultiSelect
-                      options={availableConnectors.map<MultiSelectOption>((c) => ({
-                        value: c.ref,
-                        label: c.name,
-                        secondary: c.ref.includes("/") ? c.namespace : null,
-                        searchTerms: [c.namespace, c.ref],
-                      }))}
+                      options={availableConnectors.map<MultiSelectOption>((c) => {
+                        const tpl = getConnectorTemplate(c.service);
+                        return {
+                          value: c.ref,
+                          label: c.name,
+                          secondary: c.ref.includes("/") ? c.namespace : null,
+                          searchTerms: [c.namespace, c.ref, c.service],
+                          icon: tpl?.logoUrl ? (
+                            <ConnectorLogo src={tpl.logoUrl} alt={tpl.displayName} className="h-4 w-4" />
+                          ) : undefined,
+                        };
+                      })}
                       value={values.selectedConnectors}
                       onChange={(next) => patch("selectedConnectors", next)}
                       placeholder="Select connectors..."

--- a/komputer-ui/src/components/agents/create-agent-modal.tsx
+++ b/komputer-ui/src/components/agents/create-agent-modal.tsx
@@ -127,7 +127,7 @@ export function CreateAgentModal({ open, onOpenChange, onCreated, initialValues 
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-4xl h-[85vh] flex flex-col overflow-hidden">
+      <DialogContent className="sm:max-w-5xl h-[85vh] flex flex-col overflow-hidden">
         <DialogHeader className="shrink-0">
           <DialogTitle>Create Agent</DialogTitle>
           <DialogDescription>

--- a/komputer-ui/src/components/connectors/connector-cards.tsx
+++ b/komputer-ui/src/components/connectors/connector-cards.tsx
@@ -7,6 +7,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { Button } from "@/components/kit/button";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
 import { ConnectorDetailDialog } from "@/components/connectors/connector-detail-dialog";
+import { ConnectorLogo } from "@/components/connectors/connector-logo";
 import { formatRelativeTime } from "@/lib/utils";
 import { useConnectorTemplates } from "@/hooks/use-connector-templates";
 import type { ConnectorResponse } from "@/lib/types";
@@ -44,7 +45,7 @@ export function ConnectorCards({ connectors, onDelete }: ConnectorCardsProps) {
                 <div className="flex h-full flex-col p-3">
                   <div className="flex items-center gap-2">
                     <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0">
-                      {tpl && tpl.logoUrl ? <img src={tpl.logoUrl} alt={tpl.displayName} className="w-4 h-4" /> : <Plug className="w-3.5 h-3.5" style={{ color }} />}
+                      {tpl && tpl.logoUrl ? <ConnectorLogo src={tpl.logoUrl} alt={tpl.displayName} className="w-4 h-4" /> : <Plug className="w-3.5 h-3.5" style={{ color }} />}
                     </div>
                     <div className="flex flex-col min-w-0 flex-1">
                       <span className="text-[13px] font-semibold text-[var(--color-text)] truncate leading-tight">

--- a/komputer-ui/src/components/connectors/connector-detail-dialog.tsx
+++ b/komputer-ui/src/components/connectors/connector-detail-dialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/kit/dialog";
 import { formatRelativeTime } from "@/lib/utils";
 import { useConnectorTemplates } from "@/hooks/use-connector-templates";
+import { ConnectorLogo } from "@/components/connectors/connector-logo";
 import { getConnectorTools } from "@/lib/api";
 import type { ConnectorResponse } from "@/lib/types";
 
@@ -63,7 +64,7 @@ export function ConnectorDetailDialog({ connector, open, onOpenChange }: Props) 
           <DialogTitle className="flex items-center gap-3">
             <div className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0">
               {tpl && tpl.logoUrl
-                ? <img src={tpl.logoUrl} alt={tpl.displayName} className="w-5 h-5" />
+                ? <ConnectorLogo src={tpl.logoUrl} alt={tpl.displayName} className="w-5 h-5" />
                 : <Plug className="w-4 h-4" style={{ color }} />
               }
             </div>

--- a/komputer-ui/src/components/connectors/connector-logo.tsx
+++ b/komputer-ui/src/components/connectors/connector-logo.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Renders a SimpleIcons-style connector logo, swapping `/white` ↔ `/black` to
+ * stay legible in both dark and light themes.
+ *
+ * Backend stores `https://cdn.simpleicons.org/<service>/white` (tuned for
+ * dark surfaces). At render time we inspect the `data-theme` attribute on
+ * <html> and rewrite the URL accordingly. We also subscribe to attribute
+ * changes via MutationObserver so the icon reacts when the user toggles
+ * the theme without a reload.
+ */
+export function ConnectorLogo({
+  src,
+  alt,
+  className,
+}: {
+  src: string;
+  alt: string;
+  className?: string;
+}) {
+  const [isLight, setIsLight] = useState(false);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const read = () => setIsLight(document.documentElement.getAttribute("data-theme") === "light");
+    read();
+    const obs = new MutationObserver(read);
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+    return () => obs.disconnect();
+  }, []);
+
+  const finalSrc = isLight ? src.replace(/\/white$/, "/black") : src;
+  return <img src={finalSrc} alt={alt} className={className} />;
+}

--- a/komputer-ui/src/components/connectors/create-connector-modal.tsx
+++ b/komputer-ui/src/components/connectors/create-connector-modal.tsx
@@ -17,6 +17,7 @@ import { Label } from "@/components/kit/label";
 import { NamespaceSelector } from "@/components/shared/namespace-selector";
 import { createConnector, createSecretResource, getOAuthAuthorizeUrl } from "@/lib/api";
 import { useConnectorTemplates } from "@/hooks/use-connector-templates";
+import { ConnectorLogo } from "@/components/connectors/connector-logo";
 import type { ConnectorTemplate } from "@/lib/types";
 import { ArrowLeft, Copy, Check, Plug } from "lucide-react";
 
@@ -289,7 +290,7 @@ export function CreateConnectorModal({ open, onOpenChange, onCreated, initialTem
                     <div className="flex items-center justify-center w-12 h-12 rounded-xl transition-transform duration-200 group-hover:scale-110">
                       {tpl.service === "custom"
                         ? <Plug className="w-7 h-7 text-[var(--color-text-secondary)]" />
-                        : <img src={tpl.logoUrl} alt={tpl.displayName} className="w-7 h-7" />
+                        : <ConnectorLogo src={tpl.logoUrl} alt={tpl.displayName} className="w-7 h-7" />
                       }
                     </div>
                     <div>
@@ -322,7 +323,7 @@ export function CreateConnectorModal({ open, onOpenChange, onCreated, initialTem
                     </button>
                     {selectedTemplate && (isCustom
                       ? <Plug className="w-5 h-5 text-[var(--color-text-secondary)]" />
-                      : <img src={selectedTemplate.logoUrl} alt={selectedTemplate.displayName} className="w-6 h-6" />
+                      : <ConnectorLogo src={selectedTemplate.logoUrl} alt={selectedTemplate.displayName} className="w-6 h-6" />
                     )}
                     {isCustom ? "Custom Connector" : `Connect ${selectedTemplate?.displayName}`}
                   </DialogTitle>

--- a/komputer-ui/src/components/connectors/service-template-grid.tsx
+++ b/komputer-ui/src/components/connectors/service-template-grid.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import { Plug } from "lucide-react";
 import { useConnectorTemplates } from "@/hooks/use-connector-templates";
+import { ConnectorLogo } from "@/components/connectors/connector-logo";
 import type { ConnectorTemplate } from "@/lib/types";
 
 type ServiceTemplateGridProps = {
@@ -31,7 +32,7 @@ export function ServiceTemplateGrid({ onSelect }: ServiceTemplateGridProps) {
         >
           <div className="flex items-center justify-center w-12 h-12 rounded-xl transition-transform duration-200 group-hover:scale-110">
             {tpl.logoUrl
-              ? <img src={tpl.logoUrl} alt={tpl.displayName} className="w-7 h-7" />
+              ? <ConnectorLogo src={tpl.logoUrl} alt={tpl.displayName} className="w-7 h-7" />
               : <Plug className="w-7 h-7 text-[var(--color-text-muted)]" />
             }
           </div>

--- a/komputer-ui/src/components/kit/dialog.tsx
+++ b/komputer-ui/src/components/kit/dialog.tsx
@@ -35,7 +35,11 @@ export function Dialog({ open, onOpenChange, children }: DialogProps) {
   return createPortal(
     <AnimatePresence>
       {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={() => onOpenChange(false)}>
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          style={{ paddingLeft: "var(--sidebar-width, 0px)" }}
+          onClick={() => onOpenChange(false)}
+        >
           {/* Backdrop */}
           <motion.div
             className="absolute inset-0 bg-[rgba(10,5,20,0.65)] backdrop-blur-md"
@@ -44,9 +48,15 @@ export function Dialog({ open, onOpenChange, children }: DialogProps) {
             exit={{ opacity: 0 }}
             transition={{ duration: 0.15 }}
           />
-          {/* Panel */}
+          {/*
+            Panel — sizes to its child's max-width so dialogs center properly
+            against the content area regardless of how narrow each one is. We
+            still cap at min(100%, 64rem) so very wide DialogContents still fit
+            inside the viewport. Margin guarantees a small breathing gap from
+            the screen edges on small viewports.
+          */}
           <motion.div
-            className="relative z-10 w-full max-w-[min(100%,64rem)] mx-4 flex flex-col items-stretch"
+            className="relative z-10 max-w-[min(100%,64rem)] mx-4 flex flex-col items-stretch"
             initial={{ opacity: 0, scale: 0.95, y: 10 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 10 }}

--- a/komputer-ui/src/components/kit/multi-select.tsx
+++ b/komputer-ui/src/components/kit/multi-select.tsx
@@ -22,6 +22,8 @@ export interface MultiSelectOption {
   secondary?: string | null;
   /** Optional terms added to the search index (e.g. namespace, full ref) */
   searchTerms?: string[];
+  /** Optional leading icon rendered in the dropdown row (e.g. provider logo) */
+  icon?: React.ReactNode;
 }
 
 export interface MultiSelectProps {
@@ -271,6 +273,11 @@ export function MultiSelect({
                       onMouseEnter={() => setHighlightedIndex(idx)}
                     >
                       <span className="flex items-center gap-2 min-w-0 flex-1">
+                        {opt.icon && (
+                          <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                            {opt.icon}
+                          </span>
+                        )}
                         <span className="truncate">{opt.label}</span>
                         {opt.secondary && (
                           <span className="text-[10px] text-[var(--color-brand-blue-light)] shrink-0">

--- a/komputer-ui/src/components/layout/sidebar.tsx
+++ b/komputer-ui/src/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -150,6 +150,14 @@ function CollapseButton({ collapsed, onClick }: { collapsed: boolean; onClick: (
 export function Sidebar() {
   const [collapsed, setCollapsed] = useState(false);
   const pathname = usePathname();
+
+  // Publish the sidebar width as a CSS variable on <html> so portaled
+  // overlays (dialogs) can offset their centering frame and visually align
+  // with the content area instead of the full viewport.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.documentElement.style.setProperty("--sidebar-width", collapsed ? "56px" : "210px");
+  }, [collapsed]);
 
   return (
     <TooltipProvider>


### PR DESCRIPTION
## Summary

Two threads in one PR.

**Dashboard cards expansion.** Default 4 cards (Agents, Cost, Offices, Schedules) now share the row with five new ones (Skills, Memories, Secrets, Connectors, Squads), hidden behind a horizontal scroll. Every card click-navigates; Connectors and Squads carry the same status-breakdown chips Agents already uses. Row never bleeds the page horizontally.

**Light-mode polish.**
- Connector provider logos (`cdn.simpleicons.org/<svc>/...`) swap `/white` → `/black` when `data-theme="light"` is on `<html>`. Wired into all four logo render sites including the agent form dropdown via a new `MultiSelectOption.icon` prop.
- Dialogs visually center against the content area instead of the full viewport — Sidebar publishes its width as `--sidebar-width`, kit Dialog reads it. Outer panel no longer forces `w-full`, so each dialog actually sizes to its declared max-width. Create-agent dialog bumped to `sm:max-w-5xl` so it doesn't feel narrower than before.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] Dashboard renders 4 cards by default at common viewport widths; scrolling reveals the other 5; page body never scrolls horizontally.
- [x] Cards stay equal height even when one has a long breakdown.
- [x] Hover lift + glow no longer clipped at top or bottom.
- [x] Connector dialogs (add, detail, secret detail) center properly in both themes.
- [x] GitHub/Notion connector logos swap correctly when toggling theme.
- [x] Connector dropdown in agent form shows provider icons.
