### PR TITLE
fix(ui): connector setup-guide step numbers readable in light mode

### DIFF
--- a/komputer-ui/src/app/costs/page.tsx
+++ b/komputer-ui/src/app/costs/page.tsx
@@ -192,7 +192,7 @@ export default function CostsPage() {
                   <AnimatePresence initial={false}>
                     {sorted.map((agent, i) => (
                       <motion.div
-                        key={agent.name}
+                        key={`${agent.namespace}/${agent.name}`}
                         initial={{ opacity: 0, scale: 0.97 }}
                         animate={{ opacity: 1, scale: 1 }}
                         exit={{ opacity: 0, scale: 0.97 }}

--- a/komputer-ui/src/app/page.tsx
+++ b/komputer-ui/src/app/page.tsx
@@ -524,7 +524,7 @@ export default function DashboardPage() {
                 const color = statusColors[agent.status] ?? "#8899A6";
                 return (
                   <motion.div
-                    key={agent.name}
+                    key={`${agent.namespace}/${agent.name}`}
                     initial={{ opacity: 0, scale: 0.97 }}
                     animate={{ opacity: 1, scale: 1 }}
                     transition={{ duration: 0.2, delay: 0.25 + i * 0.03 }}
@@ -586,7 +586,7 @@ export default function DashboardPage() {
               <div className="space-y-1.5 max-h-36 overflow-y-auto">
                 {runningTasks.map((agent) => (
                   <Link
-                    key={agent.name}
+                    key={`${agent.namespace}/${agent.name}`}
                     href={`/agents/${agent.name}?namespace=${agent.namespace}`}
                     className="flex items-start gap-2.5 rounded-md bg-[var(--color-bg)] p-2 transition-colors hover:bg-[var(--color-bg-subtle)] group"
                   >
@@ -639,7 +639,7 @@ export default function DashboardPage() {
 
                   return (
                     <Link
-                      key={agent.name}
+                      key={`${agent.namespace}/${agent.name}`}
                       href={`/agents/${agent.name}?namespace=${agent.namespace}`}
                       className="flex items-center gap-2.5 rounded-md bg-[var(--color-bg)] p-2 transition-colors hover:bg-[var(--color-bg-subtle)] group"
                     >

--- a/komputer-ui/src/components/agents/agent-table.tsx
+++ b/komputer-ui/src/components/agents/agent-table.tsx
@@ -54,7 +54,7 @@ export function AgentTable({ agents, onDelete }: AgentTableProps) {
         <AnimatePresence initial={false}>
           {agents.map((agent, i) => (
             <motion.tr
-              key={agent.name}
+              key={`${agent.namespace}/${agent.name}`}
               className="border-b transition-colors hover:bg-muted/50"
               initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}

--- a/komputer-ui/src/components/agents/create-agent-modal.tsx
+++ b/komputer-ui/src/components/agents/create-agent-modal.tsx
@@ -127,7 +127,7 @@ export function CreateAgentModal({ open, onOpenChange, onCreated, initialValues 
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-7xl h-[85vh] flex flex-col overflow-hidden">
+      <DialogContent className="sm:max-w-4xl h-[85vh] flex flex-col overflow-hidden">
         <DialogHeader className="shrink-0">
           <DialogTitle>Create Agent</DialogTitle>
           <DialogDescription>

--- a/komputer-ui/src/components/agents/create-agent-modal.tsx
+++ b/komputer-ui/src/components/agents/create-agent-modal.tsx
@@ -127,7 +127,7 @@ export function CreateAgentModal({ open, onOpenChange, onCreated, initialValues 
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-5xl h-[85vh] flex flex-col overflow-hidden">
+      <DialogContent className="sm:max-w-7xl h-[85vh] flex flex-col overflow-hidden">
         <DialogHeader className="shrink-0">
           <DialogTitle>Create Agent</DialogTitle>
           <DialogDescription>

--- a/komputer-ui/src/components/connectors/create-connector-modal.tsx
+++ b/komputer-ui/src/components/connectors/create-connector-modal.tsx
@@ -352,7 +352,7 @@ export function CreateConnectorModal({ open, onOpenChange, onCreated, initialTem
                             animate={{ opacity: 1, x: 0 }}
                             transition={{ duration: 0.2, delay: 0.15 + i * 0.06 }}
                           >
-                            <span className="flex items-center justify-center w-6 h-6 rounded-full text-[11px] font-semibold shrink-0 mt-0.5" style={{ backgroundColor: `${selectedTemplate.color}20`, color: selectedTemplate.color }}>
+                            <span className="flex items-center justify-center w-6 h-6 rounded-full text-[11px] font-semibold shrink-0 mt-0.5 bg-[var(--color-surface-hover)] text-[var(--color-text)] border border-[var(--color-border)]">
                               {i + 1}
                             </span>
                             <p className="text-sm text-[var(--color-text-secondary)] leading-relaxed pt-0.5">{linkify(guideStep)}</p>

--- a/komputer-ui/src/components/costs/agent-task-breakdown.tsx
+++ b/komputer-ui/src/components/costs/agent-task-breakdown.tsx
@@ -74,19 +74,21 @@ export function AgentTaskBreakdown({ agents }: { agents: AgentResponse[] }) {
     }
   };
 
-  const sortedTasks = breakdown
-    ? [...breakdown.tasks].sort((a, b) => {
+  // The API may return `tasks: null` when the agent has no tasks yet, even
+  // though the response type says it's a non-nullable array. Defensive-default
+  // to an empty array so sort/reduce don't throw.
+  const tasks = breakdown?.tasks ?? [];
+  const sortedTasks = tasks.length
+    ? [...tasks].sort((a, b) => {
         const cmp = (a[sortKey] ?? 0) - (b[sortKey] ?? 0);
         return sortDir === "asc" ? cmp : -cmp;
       })
     : [];
 
-  const mostExpensiveTask = breakdown
-    ? breakdown.tasks.reduce<TaskBreakdown | null>(
-        (best, t) => (!best || t.costUSD > best.costUSD ? t : best),
-        null
-      )
-    : null;
+  const mostExpensiveTask = tasks.reduce<TaskBreakdown | null>(
+    (best, t) => (!best || t.costUSD > best.costUSD ? t : best),
+    null,
+  );
 
   return (
     <Card className="border-[var(--color-border)] bg-[var(--color-surface)]">
@@ -140,7 +142,7 @@ export function AgentTaskBreakdown({ agents }: { agents: AgentResponse[] }) {
           </p>
         ) : error ? (
           <p className="py-8 text-center text-sm text-red-400">{error}</p>
-        ) : breakdown && breakdown.tasks.length === 0 ? (
+        ) : breakdown && tasks.length === 0 ? (
           <p className="py-8 text-center text-sm text-[var(--color-text-secondary)]">
             No completed tasks found for this agent.
           </p>

--- a/komputer-ui/src/components/kit/dialog.tsx
+++ b/komputer-ui/src/components/kit/dialog.tsx
@@ -49,14 +49,13 @@ export function Dialog({ open, onOpenChange, children }: DialogProps) {
             transition={{ duration: 0.15 }}
           />
           {/*
-            Panel — sizes to its child's max-width so dialogs center properly
-            against the content area regardless of how narrow each one is. We
-            still cap at min(100%, 64rem) so very wide DialogContents still fit
-            inside the viewport. Margin guarantees a small breathing gap from
-            the screen edges on small viewports.
+            Panel — fills the available width up to 80rem; the inner
+            DialogContent applies its own max-w-* to cap the visible card.
+            Centering happens in the parent flex frame which already accounts
+            for sidebar offset via --sidebar-width.
           */}
           <motion.div
-            className="relative z-10 max-w-[min(100%,80rem)] mx-4 flex flex-col items-stretch"
+            className="relative z-10 w-full max-w-[min(100%,80rem)] mx-4 flex flex-col items-center"
             initial={{ opacity: 0, scale: 0.95, y: 10 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 10 }}
@@ -85,6 +84,10 @@ export function DialogContent({
         "shadow-[0_8px_32px_rgba(0,0,0,0.4),0_2px_8px_rgba(0,0,0,0.2),inset_0_1px_0_var(--color-border-light)]",
         "w-full flex flex-col",
         "p-6 text-[var(--color-text)]",
+        // Cap the visible card width per-instance via the className override.
+        // Default cap matches the previous 64rem panel cap so existing dialogs
+        // without an explicit max-w-* in className don't suddenly fill 80rem.
+        "max-w-[64rem]",
         className,
       )}
       {...props}

--- a/komputer-ui/src/components/kit/dialog.tsx
+++ b/komputer-ui/src/components/kit/dialog.tsx
@@ -56,7 +56,7 @@ export function Dialog({ open, onOpenChange, children }: DialogProps) {
             the screen edges on small viewports.
           */}
           <motion.div
-            className="relative z-10 max-w-[min(100%,64rem)] mx-4 flex flex-col items-stretch"
+            className="relative z-10 max-w-[min(100%,80rem)] mx-4 flex flex-col items-stretch"
             initial={{ opacity: 0, scale: 0.95, y: 10 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 10 }}

--- a/komputer-ui/src/components/layout/sidebar.tsx
+++ b/komputer-ui/src/components/layout/sidebar.tsx
@@ -24,21 +24,40 @@ import {
 } from "lucide-react";
 import { TooltipProvider } from "@/components/kit/tooltip";
 
-const navItems = [
-  { label: "Dashboard", icon: LayoutDashboard, href: "/" },
-  { label: "Agents", icon: Bot, href: "/agents" },
-  { label: "Memories", icon: Brain, href: "/memories" },
-  { label: "Skills", icon: Wand2, href: "/skills" },
-  { label: "Secrets", icon: KeyRound, href: "/secrets" },
-  { label: "Connectors", icon: Plug, href: "/connectors" },
-  { label: "Offices", icon: Building2, href: "/offices" },
-  { label: "Squads", icon: Users, href: "/squads" },
-  { label: "Schedules", icon: Clock, href: "/schedules" },
-  { label: "Topology", icon: Network, href: "/topology" },
-  { label: "Cost", icon: DollarSign, href: "/costs" },
+type NavItemDef = { label: string; icon: typeof LayoutDashboard; href: string };
+type NavSection = { title: string | null; items: NavItemDef[] };
+
+const navSections: NavSection[] = [
+  {
+    title: null,
+    items: [{ label: "Dashboard", icon: LayoutDashboard, href: "/" }],
+  },
+  {
+    title: "Core",
+    items: [
+      { label: "Agents", icon: Bot, href: "/agents" },
+      { label: "Memories", icon: Brain, href: "/memories" },
+      { label: "Skills", icon: Wand2, href: "/skills" },
+      { label: "Secrets", icon: KeyRound, href: "/secrets" },
+      { label: "Connectors", icon: Plug, href: "/connectors" },
+    ],
+  },
+  {
+    title: "Orchestration",
+    items: [
+      { label: "Offices", icon: Building2, href: "/offices" },
+      { label: "Squads", icon: Users, href: "/squads" },
+      { label: "Schedules", icon: Clock, href: "/schedules" },
+      { label: "Topology", icon: Network, href: "/topology" },
+    ],
+  },
+  {
+    title: "System",
+    items: [{ label: "Cost", icon: DollarSign, href: "/costs" }],
+  },
 ];
 
-const bottomItems: typeof navItems = [
+const bottomItems: NavItemDef[] = [
   // { label: "Settings", icon: Settings, href: "/settings" },
 ];
 
@@ -47,7 +66,7 @@ function NavItem({
   isActive,
   collapsed,
 }: {
-  item: (typeof navItems)[0];
+  item: NavItemDef;
   isActive: boolean;
   collapsed: boolean;
 }) {
@@ -197,19 +216,37 @@ export function Sidebar() {
           </div>
         )}
 
-        {/* Main nav */}
+        {/* Main nav — grouped into Core / Orchestration / System sections.
+            Section headers hide when the sidebar is collapsed (icons only). */}
         <nav className="flex-1 flex flex-col gap-0.5 px-2 py-3 overflow-y-auto">
-          {navItems.map((item) => (
-            <NavItem
-              key={item.href}
-              item={item}
-              isActive={
-                item.href === "/"
-                  ? pathname === "/"
-                  : pathname.startsWith(item.href)
-              }
-              collapsed={collapsed}
-            />
+          {navSections.map((section, sectionIdx) => (
+            <div key={section.title ?? `__top-${sectionIdx}`} className="flex flex-col gap-0.5">
+              {section.title && !collapsed && (
+                <>
+                  {sectionIdx > 0 && (
+                    <div className="mx-3 mt-2 border-t border-[var(--color-border)]/50" />
+                  )}
+                  <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+                    {section.title}
+                  </div>
+                </>
+              )}
+              {section.title && collapsed && sectionIdx > 0 && (
+                <div className="my-2 mx-3 border-t border-[var(--color-border)]/50" />
+              )}
+              {section.items.map((item) => (
+                <NavItem
+                  key={item.href}
+                  item={item}
+                  isActive={
+                    item.href === "/"
+                      ? pathname === "/"
+                      : pathname.startsWith(item.href)
+                  }
+                  collapsed={collapsed}
+                />
+              ))}
+            </div>
           ))}
         </nav>
 

--- a/komputer-ui/src/components/memories/memory-cards.tsx
+++ b/komputer-ui/src/components/memories/memory-cards.tsx
@@ -19,7 +19,7 @@ export function MemoryCards({ memories, onDelete }: MemoryCardsProps) {
       <AnimatePresence>
         {memories.map((memory, i) => (
           <motion.div
-            key={memory.name}
+            key={`${memory.namespace}/${memory.name}`}
             initial={{ opacity: 0, y: 12, scale: 0.97 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, scale: 0.97 }}

--- a/komputer-ui/src/components/secrets/create-secret-modal.tsx
+++ b/komputer-ui/src/components/secrets/create-secret-modal.tsx
@@ -103,7 +103,7 @@ export function CreateSecretModal({ open, onOpenChange, onCreated }: CreateSecre
         if (!nextOpen) resetForm();
       }}
     >
-      <DialogContent>
+      <DialogContent className="max-w-3xl">
         <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
           <DialogHeader>
             <DialogTitle>Create Secret</DialogTitle>
@@ -112,7 +112,7 @@ export function CreateSecretModal({ open, onOpenChange, onCreated }: CreateSecre
             </DialogDescription>
           </DialogHeader>
 
-          <div className="mt-4 flex flex-col gap-4 overflow-y-auto flex-1 pr-1">
+          <div className="mt-4 flex flex-col gap-4 overflow-y-auto flex-1 px-2 py-2">
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="secret-name">Name</Label>
               <Input

--- a/komputer-ui/src/components/skills/create-skill-modal.tsx
+++ b/komputer-ui/src/components/skills/create-skill-modal.tsx
@@ -85,7 +85,7 @@ export function CreateSkillModal({ open, onOpenChange, onCreated }: CreateSkillM
         if (!nextOpen) resetForm();
       }}
     >
-      <DialogContent>
+      <DialogContent className="max-w-3xl">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Create Skill</DialogTitle>

--- a/komputer-ui/src/components/skills/skill-cards.tsx
+++ b/komputer-ui/src/components/skills/skill-cards.tsx
@@ -19,7 +19,7 @@ export function SkillCards({ skills, onDelete }: SkillCardsProps) {
       <AnimatePresence>
         {skills.map((skill, i) => (
           <motion.div
-            key={skill.name}
+            key={`${skill.namespace}/${skill.name}`}
             initial={{ opacity: 0, y: 12, scale: 0.97 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, scale: 0.97 }}


### PR DESCRIPTION
Step circles previously used the connector brand color over a 12.5%-alpha tint of the same. For brands with light-gray hex values like GitHub or Notion, the tint becomes invisible on a near-white surface in light mode and the digit disappears with it. Switch to design-system tokens (surface-hover bg, text fg, border) so the chip reads consistently in both themes.