### PR TITLE
feat: thinking-time counter, schedule manual-trigger, MCP server + docs examples

### DIFF
--- a/docs-site/src/lib/release.ts
+++ b/docs-site/src/lib/release.ts
@@ -11,8 +11,8 @@ interface ReleaseInfo {
 }
 
 const FALLBACK: ReleaseInfo = {
-  tag: 'v0.14.0',
-  name: 'v0.14.0 — Squads',
+  tag: 'v0.15.9',
+  name: 'v0.15.9 — Namespace & Timestamp Polish',
   url: 'https://github.com/komputer-ai/komputer-ai/releases',
 };
 

--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -9,3 +9,51 @@ description: Cluster-scoped singleton that holds platform-wide settings.
 - **API URL** — The internal cluster URL of the komputer-api service. Manager agents use this to create and manage sub-agents via HTTP.
 
 The operator auto-discovers this resource — agents and templates don't need to reference it explicitly.
+
+## Minimal config
+
+The Helm chart installs this for you. You only need to author one by hand if you're managing the install via raw manifests or pointing at an externally-managed Redis.
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerConfig
+metadata:
+  name: komputer
+spec:
+  redis:
+    address: komputer-redis.komputer-ai.svc.cluster.local:6379
+  apiURL: http://komputer-api.komputer-ai.svc.cluster.local:8080
+```
+
+## Config with auth + custom DB
+
+When Redis is shared with other workloads, isolate by `db` and `streamPrefix` and authenticate via a Secret:
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerConfig
+metadata:
+  name: komputer
+spec:
+  redis:
+    address: redis.shared-infra.svc.cluster.local:6379
+    db: 3
+    streamPrefix: komputer-events-prod      # default: "komputer-events"
+    passwordSecret:
+      name: shared-redis-creds              # K8s Secret
+      key: password
+      # namespace: shared-infra             # optional; defaults to install namespace
+  apiURL: http://komputer-api.komputer-ai.svc.cluster.local:8080
+```
+
+## Verifying
+
+```bash
+kubectl get komputerconfig
+# NAME       AGE
+# komputer   17d
+
+kubectl describe komputerconfig komputer
+```
+
+The API and operator log a `redis worker started` message at boot with the resolved address — if you see that, the config is loaded.

--- a/docs/concepts/connectors.md
+++ b/docs/concepts/connectors.md
@@ -85,3 +85,41 @@ These services don't expose a remote MCP endpoint that fits our model. To use th
 ### Adding your own
 
 Any MCP-compatible endpoint can be added as a custom connector — just create a `KomputerConnector` pointing at the URL and (optionally) referencing an auth secret. See the example above.
+
+## Attaching at runtime
+
+You don't have to bake connectors into the agent's spec at creation time. PATCH `spec.connectors` on a running agent and the change takes effect on the agent's next task — no pod restart needed.
+
+```bash
+# Add github + linear to an already-running agent
+curl -X PATCH http://komputer-api/api/v1/agents/my-agent \
+  -H "Content-Type: application/json" \
+  -d '{"connectors": ["github", "linear"]}'
+
+# Remove all connectors
+curl -X PATCH http://komputer-api/api/v1/agents/my-agent \
+  -H "Content-Type: application/json" \
+  -d '{"connectors": []}'
+```
+
+A manager agent can do the same via the `attach_connector` / `detach_connector` MCP tools — see the per-tool descriptions in `komputer-agent/manager_tools.py`. Office sub-agents automatically inherit their manager's connectors at creation time.
+
+## Self-hosted custom MCP server
+
+Point a `KomputerConnector` at any in-cluster service that speaks MCP:
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerConnector
+metadata:
+  name: internal-search
+  namespace: default
+spec:
+  service: custom
+  url: "http://my-mcp-server.tools.svc.cluster.local:8080/mcp"
+  authSecretKeyRef:
+    name: internal-search-token
+    key: token
+```
+
+Agents that attach `internal-search` will see this server's tools as `mcp__internal_search__*`.

--- a/docs/concepts/offices.md
+++ b/docs/concepts/offices.md
@@ -13,3 +13,64 @@ Offices are created automatically when a manager agent creates its first sub-age
 - Total cost across all members
 
 This is primarily a status/observability resource — you don't create offices directly, they emerge from manager-worker interactions.
+
+## Inspecting an office
+
+```bash
+kubectl get komputeroffices -n team-platform
+# NAME              PHASE        MANAGER        AGENTS  ACTIVE  COST
+# release-cutover   InProgress   release-mgr    4       2       0.2418
+```
+
+A single office details view:
+
+```bash
+kubectl get komputeroffice release-cutover -n team-platform -o yaml
+```
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerOffice
+metadata:
+  name: release-cutover
+  namespace: team-platform
+spec:
+  manager: release-mgr           # the only field on .spec
+status:
+  phase: InProgress              # InProgress | Complete | Error
+  manager:
+    name: release-mgr
+    role: manager
+    taskStatus: InProgress
+    lastTaskCostUSD: "0.0823"
+  members:
+    - name: changelog-writer
+      role: worker
+      taskStatus: Complete
+      lastTaskCostUSD: "0.0411"
+    - name: release-notes-poster
+      role: worker
+      taskStatus: InProgress
+      lastTaskCostUSD: "0.0294"
+    - name: smoke-tester
+      role: worker
+      taskStatus: Complete
+      lastTaskCostUSD: "0.0890"
+  totalAgents: 4
+  activeAgents: 2
+  completedAgents: 2
+  totalCostUSD: "0.2418"
+  totalTokens: 184223
+  createdAt: "2026-06-06T14:02:11Z"
+```
+
+Or via the API:
+
+```bash
+curl http://komputer-api/api/v1/offices/release-cutover?namespace=team-platform
+curl http://komputer-api/api/v1/offices?namespace=team-platform                # list
+```
+
+## Connector inheritance
+
+When a manager creates a sub-agent, the operator copies the manager's `spec.connectors` onto the new worker so it inherits the same MCP tools (GitHub, Slack, etc.). You can override per-agent at create time. See `concepts/connectors.md`.

--- a/docs/concepts/schedules.md
+++ b/docs/concepts/schedules.md
@@ -19,6 +19,75 @@ Key features:
 
 Schedules default to `Sleep` lifecycle for their agents, so compute is only used during the actual task execution.
 
+## Minimal schedule
+
+A nightly summary, GitOps-friendly:
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerSchedule
+metadata:
+  name: nightly-signups
+spec:
+  schedule: "0 2 * * *"                # 02:00 every day
+  timezone: "America/New_York"
+  instructions: >
+    Pull yesterday's signups from the analytics warehouse and post a one-line
+    summary to Slack #growth. Highlight any anomalies vs. the trailing 7-day avg.
+  agent:
+    model: claude-sonnet-4-6
+    lifecycle: Sleep                   # pod is torn down between runs (default)
+```
+
+The `agent` block lets the schedule create its own dedicated agent on first fire. If you want the schedule to drive an **existing** agent instead, set `spec.agentName` (and omit `spec.agent`).
+
+## Full schedule with template + secrets
+
+A weekday-9am stand-up bot that uses a custom template and references existing secrets and a connector. This is the shape you'd reach for in production.
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerSchedule
+metadata:
+  name: weekday-standup
+  namespace: team-product
+spec:
+  schedule: "0 9 * * 1-5"              # 09:00 Mon–Fri
+  timezone: "Europe/Berlin"
+  instructions: >
+    Fetch yesterday's merged PRs from Linear, summarise per assignee, and
+    post the digest to Slack #product-standup. Use the linear and slack
+    connector tools.
+  agent:
+    model: claude-sonnet-4-6
+    lifecycle: Sleep
+    role: manager
+    templateRef: lightweight           # see concepts/templates.md
+    secrets:
+      - linear-credentials
+      - slack-bot-token
+```
+
+## One-off scheduled run
+
+Use `autoDelete: true` to schedule a single future run that cleans itself up afterwards. Combine with `keepAgents: true` if you want the agent it created to survive.
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerSchedule
+metadata:
+  name: launch-eod-recap
+spec:
+  schedule: "0 18 30 6 *"              # 18:00 on June 30 (single instant)
+  timezone: "UTC"
+  autoDelete: true
+  keepAgents: true                     # keep the agent it spawns
+  instructions: "Compile a launch-day recap into /workspace/recap.md."
+  agent:
+    model: claude-sonnet-4-6
+    lifecycle: Sleep
+```
+
 ## Editing a schedule
 
 Both the cron expression and the instructions can be updated after creation. In the UI, the schedule detail page has inline edit controls for both. From the CLI:

--- a/docs/concepts/schedules.md
+++ b/docs/concepts/schedules.md
@@ -8,11 +8,44 @@ A **KomputerSchedule** runs agent tasks on a cron schedule. Use it for recurring
 Key features:
 
 - **Cron expression** — Standard 5-field cron (`min hour dom month dow`)
+- **Instructions** — The task prompt the agent runs every tick (editable after creation)
 - **Timezone** — IANA timezone support (defaults to UTC)
 - **Suspend/resume** — Pause schedules without deleting them
 - **Auto-delete** — Optionally delete the schedule after the first successful run
 - **Keep agents** — When auto-deleting, optionally keep the created agents alive
 - **Agent configuration** — Specify model, role, lifecycle, template, and secrets for created agents
 - **Cost tracking** — Tracks total cost and per-run cost across all scheduled runs
+- **Manual trigger** — Fire a schedule immediately, outside its cron cadence (UI: "Run now"; CLI: `komputer schedule trigger <name>`)
 
 Schedules default to `Sleep` lifecycle for their agents, so compute is only used during the actual task execution.
+
+## Editing a schedule
+
+Both the cron expression and the instructions can be updated after creation. In the UI, the schedule detail page has inline edit controls for both. From the CLI:
+
+```bash
+komputer schedule update my-schedule --cron "0 9 * * 1-5"
+komputer schedule update my-schedule --instructions "Summarize yesterday's signups."
+```
+
+## Manual trigger
+
+You can fire a schedule outside its normal cron cadence. The schedule's next cron run is unaffected — this is purely an extra one-off run.
+
+```bash
+komputer schedule trigger my-schedule
+# or
+curl -X POST http://komputer-api/api/v1/schedules/my-schedule/trigger
+```
+
+The trigger returns `409 Conflict` if the schedule's last run is still in progress.
+
+## Failure behavior
+
+If a scheduled run fails (the agent returns an error), the schedule keeps firing at the next cron tick — failures do not pause the schedule. Only three things stop future runs:
+
+- The schedule is suspended (`spec.suspended: true`)
+- The schedule is `autoDelete: true` and has completed (it deletes itself)
+- The cron expression is invalid (phase becomes `Error`)
+
+The `failedRuns` counter in the status surfaces past failures so you can spot a repeatedly-failing schedule without it ever blocking itself.

--- a/docs/concepts/squads/index.md
+++ b/docs/concepts/squads/index.md
@@ -25,3 +25,72 @@ Inside the squad Pod each agent sees:
 | `/agents/<sibling-name>/workspace` | Each sibling agent's workspace (read/write) |
 
 All paths are read-write. There is no enforced isolation between members — any agent can write to a sibling's workspace.
+
+## Inline members — create a squad with new agents
+
+Each `members` entry can be a full inline agent spec. This is the one-shot path: declare the squad and its brand-new members in a single CR.
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerSquad
+metadata:
+  name: review-pair
+  namespace: team-platform
+spec:
+  members:
+    - name: coder                       # KomputerAgent will be created with this name
+      spec:
+        instructions: "Implement the feature described in /agents/reviewer/workspace/SPEC.md."
+        model: claude-sonnet-4-6
+        role: worker
+        lifecycle: Sleep
+        templateRef: default
+    - name: reviewer
+      spec:
+        instructions: "Drop a SPEC.md in your workspace, then review the coder's diff and write feedback."
+        model: claude-sonnet-4-6
+        role: worker
+        lifecycle: Sleep
+        templateRef: default
+```
+
+Inside the squad Pod each member sees both workspaces:
+
+```
+/agents/coder/workspace        # coder's own PVC
+/agents/reviewer/workspace     # reviewer's PVC, also mounted in the coder container (and vice-versa)
+/workspace                     # alias for the current member's own workspace
+```
+
+## Member refs — bring existing agents into a squad
+
+Use `ref` when the agents already exist as `KomputerAgent` CRs and you just want to co-locate them. Mix `ref` and inline `spec` freely in the same `members` list.
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerSquad
+metadata:
+  name: rebuild-strike-team
+spec:
+  members:
+    - ref: { name: senior-architect }     # existing agent
+    - ref: { name: legacy-explorer }      # existing agent
+    - name: scribe                         # plus one brand-new member inline
+      spec:
+        instructions: "Take notes from the conversation in /agents/*/workspace and write a refactor plan."
+        role: worker
+        lifecycle: Sleep
+```
+
+A given agent can only be a member of **one** squad at a time — see `caveats.md`.
+
+## Tuning lifecycle
+
+```yaml
+spec:
+  orphanTTL: "30m"          # delete the squad if every member is asleep this long (default: 10m)
+  breakUpRequested: true    # gracefully dissolve once all members are sleeping; PVCs survive
+  members: [...]
+```
+
+See `lifecycle.md` for the state-machine details, `manager-tools.md` for the MCP tools a manager agent uses to spin up squads on the fly, and `gitops.md` for the `ref`-vs-`spec` tradeoffs in declarative setups.

--- a/docs/concepts/templates.md
+++ b/docs/concepts/templates.md
@@ -13,3 +13,140 @@ There are two kinds of templates:
 When an agent is created, it references a template by name (defaulting to `"default"`). The operator resolves the template — checking the agent's namespace first, then falling back to cluster scope — and uses it to build the pod.
 
 **Important:** Every template must set `spec.anthropicKeySecretRef` — a typed reference (`name`, `key`, optional `namespace`) pointing at the Secret holding your Anthropic API key. The operator mirrors that secret into the agent's namespace and injects `ANTHROPIC_API_KEY` into the pod automatically; you must **not** add `ANTHROPIC_API_KEY` to the template's `podSpec.env` yourself (the operator strips it if you do). When `namespace` is empty, the operator reads from the namespace komputer-ai was deployed into.
+
+## Minimal cluster template
+
+The simplest usable template. This is roughly what the Helm chart installs as `default`:
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerAgentClusterTemplate
+metadata:
+  name: default
+spec:
+  anthropicKeySecretRef:
+    name: anthropic-api-key       # K8s Secret in the komputer-ai install namespace
+    key: token                    # key inside that Secret
+  storage:
+    size: 10Gi
+  podSpec:
+    containers:
+      - name: agent
+        image: ghcr.io/komputer-ai/komputer-agent:latest
+        resources:
+          requests: { cpu: "500m", memory: "1Gi" }
+          limits:   { cpu: "2",    memory: "4Gi" }
+```
+
+Every agent that doesn't override `spec.templateRef` uses this template.
+
+## Advanced cluster template
+
+A production-grade template with concurrency cap, node selection, custom env, additional volumes, and a non-default image. All standard Kubernetes PodSpec fields are passed through verbatim.
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerAgentClusterTemplate
+metadata:
+  name: gpu-heavy
+spec:
+  anthropicKeySecretRef:
+    name: anthropic-api-key
+    key: token
+
+  # Cap how many agents using this template can run concurrently per namespace.
+  # 0 (default) = no cap. See concepts/agents.md "Concurrency Control".
+  maxConcurrentAgents: 5
+
+  storage:
+    size: 100Gi
+    storageClassName: fast-ssd
+
+  podSpec:
+    serviceAccountName: komputer-agent
+    nodeSelector:
+      workload-class: ai-heavy
+    tolerations:
+      - key: gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+    containers:
+      - name: agent
+        image: ghcr.io/my-org/komputer-agent-custom:v3.2.1
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: OPENAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: openai-creds
+                key: token
+          - name: COMPANY_REGION
+            value: us-east-1
+        resources:
+          requests: { cpu: "2", memory: "8Gi", nvidia.com/gpu: "1" }
+          limits:   { cpu: "4", memory: "16Gi", nvidia.com/gpu: "1" }
+        volumeMounts:
+          - name: shared-prompts
+            mountPath: /shared/prompts
+            readOnly: true
+    volumes:
+      - name: shared-prompts
+        configMap:
+          name: prompt-library
+```
+
+## Namespace-scoped override
+
+A `KomputerAgentTemplate` (note: no `Cluster`) lets a single team customize a template name without affecting other namespaces. When both exist, the namespace-scoped one wins **for agents in that namespace**.
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerAgentTemplate
+metadata:
+  name: default                  # same name as a cluster template — overrides it for this ns
+  namespace: team-research
+spec:
+  anthropicKeySecretRef:
+    name: anthropic-api-key
+    key: token
+    namespace: komputer-ai       # explicit ns means the operator pulls from here, then mirrors in
+  storage:
+    size: 50Gi
+  podSpec:
+    containers:
+      - name: agent
+        image: ghcr.io/my-org/komputer-agent-research:latest
+        resources:
+          requests: { cpu: "1", memory: "2Gi" }
+          limits:   { cpu: "2", memory: "4Gi" }
+```
+
+## Referencing a template from an agent
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerAgent
+metadata:
+  name: heavy-research
+  namespace: team-research
+spec:
+  instructions: "Build a literature review on transformer scaling laws."
+  templateRef: gpu-heavy         # by name; resolution checks ns then cluster scope
+  model: claude-sonnet-4-6
+```
+
+Via the API:
+
+```bash
+curl -X POST http://komputer-api/api/v1/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "heavy-research",
+    "instructions": "Build a literature review on transformer scaling laws.",
+    "templateRef": "gpu-heavy",
+    "namespace": "team-research"
+  }'
+```
+
+See `concepts/agents.md` for how `spec.podSpec` and `spec.storage` on the **agent** itself further override the template's pod for a single agent (e.g. one-off memory bump).

--- a/docs/integration/mcp-server.md
+++ b/docs/integration/mcp-server.md
@@ -1,0 +1,104 @@
+---
+title: MCP Server
+description: Drive komputer-ai from other Claude agents via the built-in MCP server.
+---
+
+`komputer-api` exposes its capabilities over the [Model Context Protocol](https://modelcontextprotocol.io/) so external Claude agents (Claude Code, custom Claude SDK clients, anything MCP-aware) can list, create, and trigger komputer-ai resources as tools.
+
+## Endpoint
+
+All MCP traffic goes to a single path on the API server:
+
+```
+POST <komputer-api-base-url>/mcp
+```
+
+**You must configure your client with this exact path** — it's not the API root, it's `/mcp`. For example, if your API is reachable at `https://komputer.example.com`, the MCP endpoint is `https://komputer.example.com/mcp`.
+
+The server uses the standard MCP streamable HTTP transport. No special headers required beyond the MCP protocol handshake.
+
+## Authentication
+
+There is **no auth** on the `/mcp` endpoint today — it matches the rest of the API's posture. Anyone who can reach the endpoint can drive your cluster's komputer-ai resources. Lock down access at the network or ingress layer (e.g. behind a VPN, internal-only ingress, network policy).
+
+## Configuring a client
+
+### Claude Code
+
+Add a custom MCP server in `~/.claude/settings.json` (or your project's `.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "komputer-ai": {
+      "type": "http",
+      "url": "https://komputer.example.com/mcp"
+    }
+  }
+}
+```
+
+Restart Claude Code; the tools below appear under the `komputer-ai` server.
+
+### Another komputer-ai cluster
+
+Create a `KomputerConnector` pointing at the remote `/mcp`:
+
+```yaml
+apiVersion: komputer.komputer.ai/v1alpha1
+kind: KomputerConnector
+metadata:
+  name: remote-komputer
+spec:
+  type: http
+  url: https://komputer.example.com/mcp
+```
+
+Then attach `remote-komputer` to any agent that should be able to drive the remote cluster.
+
+### Generic MCP client
+
+Point any streamable-HTTP MCP client at `<api-url>/mcp`. The server reports `serverInfo: { name: "komputer-ai", version: "v1" }` during the `initialize` handshake.
+
+## Tools
+
+The current tool set is focused on the most useful remote-control surface. All tools accept an optional `namespace` argument; when omitted, the API's default namespace is used.
+
+| Tool | Purpose |
+|------|---------|
+| `list_agents` | List agents in a namespace (or all namespaces) |
+| `get_agent` | Full spec + status + costs for one agent |
+| `list_schedules` | List schedules in a namespace |
+| `get_schedule` | Full schedule including current `instructions` |
+| `trigger_schedule` | Fire a schedule immediately, outside its cron cadence |
+| `list_memories` | List `KomputerMemory` resources |
+| `get_memory` | Get a memory's content and description |
+| `list_skills` | List `KomputerSkill` resources |
+| `get_skill` | Get a skill's full body |
+| `list_connectors` | List configured MCP connectors |
+| `list_secrets` | List secret names (values are never returned) |
+| `list_namespaces` | List Kubernetes namespaces visible to the API |
+| `list_templates` | List `KomputerAgentTemplate` / `KomputerAgentClusterTemplate` resources |
+
+More write-side tools (create agent, attach memory, etc.) are likely to be added — open an issue if there's a specific one you need.
+
+## Quick smoke test
+
+A bare `curl` round-trip confirms the endpoint is reachable and your client will see the tool list:
+
+```bash
+# 1. Initialize a session and capture the session id from the response headers.
+curl -i -X POST https://komputer.example.com/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize",
+       "params":{"protocolVersion":"2025-06-18","capabilities":{},
+                 "clientInfo":{"name":"smoke-test","version":"0.1"}}}'
+
+# 2. Use the Mcp-Session-Id header from above on subsequent calls.
+curl -X POST https://komputer.example.com/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+```

--- a/docs/integration/meta.json
+++ b/docs/integration/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Integration",
   "defaultOpen": false,
-  "pages": ["overview", "rest-api", "websocket", "patterns", "error-handling", "custom-agent-image"]
+  "pages": ["overview", "rest-api", "mcp-server", "websocket", "patterns", "error-handling", "custom-agent-image"]
 }

--- a/docs/integration/rest-api.md
+++ b/docs/integration/rest-api.md
@@ -185,3 +185,65 @@ curl -X PATCH http://localhost:8080/api/v1/agents/my-agent \
   -H "Content-Type: application/json" \
   -d '{"connectors": []}'
 ```
+
+## Schedules
+
+A schedule runs an agent task on a cron cadence. See [Schedules](../concepts/schedules.md) for the concept overview.
+
+### Create a Schedule
+
+```
+POST /api/v1/schedules
+Content-Type: application/json
+```
+
+```json
+{
+  "name": "nightly-report",
+  "schedule": "0 2 * * *",
+  "instructions": "Summarize yesterday's signups and post to Slack.",
+  "timezone": "America/New_York",
+  "agent": { "lifecycle": "Sleep", "model": "claude-sonnet-4-6" }
+}
+```
+
+### List / Get / Delete Schedules
+
+```
+GET    /api/v1/schedules?namespace=default
+GET    /api/v1/schedules/:name?namespace=default
+DELETE /api/v1/schedules/:name?namespace=default
+```
+
+The response includes the schedule's `instructions`, current `phase`, `nextRunTime`, `runCount`, `successfulRuns`, `failedRuns`, and cost totals.
+
+### Update a Schedule
+
+```
+PATCH /api/v1/schedules/:name
+Content-Type: application/json
+```
+
+```json
+{
+  "schedule": "0 9 * * 1-5",
+  "instructions": "Updated task prompt..."
+}
+```
+
+Both fields are optional; pass either or both.
+
+### Trigger a Schedule Manually
+
+Fire a schedule immediately, outside its cron cadence. The schedule's normal next run is unaffected.
+
+```
+POST /api/v1/schedules/:name/trigger?namespace=default
+```
+
+**Response (200 OK):**
+```json
+{ "status": "triggered", "name": "nightly-report", "agentName": "nightly-report-agent" }
+```
+
+Returns `409 Conflict` if the previous run is still in progress.

--- a/komputer-agent/manager_tools.py
+++ b/komputer-agent/manager_tools.py
@@ -232,6 +232,22 @@ async def delete_schedule(args):
 
 
 @tool(
+    name="trigger_schedule",
+    description="Trigger a schedule to run NOW, outside of its cron cadence. Useful for debugging or for one-off manual runs of a recurring task.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "The schedule name (as passed to schedule_agent)."},
+        },
+        "required": ["name"],
+    },
+)
+async def trigger_schedule(args):
+    full_name = _sanitize_name(args["name"])
+    return await _request("POST", f"/api/v1/schedules/{full_name}/trigger", timeout=30)
+
+
+@tool(
     name="create_memory",
     description="Create a KomputerMemory resource containing reusable knowledge (notes, context, instructions). Optionally attach it to yourself so it's included in your system prompt on next wake.",
     input_schema={
@@ -1295,5 +1311,5 @@ def create_manager_server():
     """Create the MCP server with manager orchestration tools."""
     return create_sdk_mcp_server(
         name="komputer",
-        tools=[create_agent, schedule_agent, get_agent_status, get_agent_events, cancel_agent, delete_agent, delete_schedule, list_schedules, get_schedule, update_schedule, create_memory, attach_memory, create_skill, attach_skill, update_agent, sleep_agent, wake_agent, list_agents, patch_agent, get_agent, list_connectors, list_connector_templates, get_connector, attach_connector, detach_connector, list_secrets, create_secret, delete_secret, attach_secret, detach_secret, list_skills, get_skill, update_skill, delete_skill, detach_skill, list_memories, get_memory, update_memory, delete_memory, detach_memory, list_namespaces, list_templates, create_squad, add_to_squad, remove_from_squad, delete_squad, list_squads],
+        tools=[create_agent, schedule_agent, get_agent_status, get_agent_events, cancel_agent, delete_agent, delete_schedule, trigger_schedule, list_schedules, get_schedule, update_schedule, create_memory, attach_memory, create_skill, attach_skill, update_agent, sleep_agent, wake_agent, list_agents, patch_agent, get_agent, list_connectors, list_connector_templates, get_connector, attach_connector, detach_connector, list_secrets, create_secret, delete_secret, attach_secret, detach_secret, list_skills, get_skill, update_skill, delete_skill, detach_skill, list_memories, get_memory, update_memory, delete_memory, detach_memory, list_namespaces, list_templates, create_squad, add_to_squad, remove_from_squad, delete_squad, list_squads],
     )

--- a/komputer-api/go.mod
+++ b/komputer-api/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
@@ -68,6 +69,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -79,10 +81,13 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -92,7 +97,7 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/komputer-api/go.sum
+++ b/komputer-api/go.sum
@@ -106,6 +106,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -130,6 +132,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
 github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
+github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -166,6 +170,10 @@ github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfS
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -192,6 +200,8 @@ github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
@@ -228,6 +238,8 @@ golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
 golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/komputer-api/handler_schedules.go
+++ b/komputer-api/handler_schedules.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	komputerv1alpha1 "github.com/komputer-ai/komputer-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CreateScheduleRequest struct {
@@ -33,6 +37,7 @@ type ScheduleResponse struct {
 	Name           string `json:"name"`
 	Namespace      string `json:"namespace"`
 	Schedule       string `json:"schedule"`
+	Instructions   string `json:"instructions"`
 	Timezone       string `json:"timezone,omitempty"`
 	AutoDelete     bool   `json:"autoDelete,omitempty"`
 	KeepAgents     bool   `json:"keepAgents,omitempty"`
@@ -56,7 +61,14 @@ type ScheduleListResponse struct {
 }
 
 type PatchScheduleRequest struct {
-	Schedule *string `json:"schedule,omitempty"`
+	Schedule     *string `json:"schedule,omitempty"`
+	Instructions *string `json:"instructions,omitempty"`
+}
+
+type TriggerScheduleResponse struct {
+	Status    string `json:"status"`
+	Name      string `json:"name"`
+	AgentName string `json:"agentName"`
 }
 
 // scheduleToResponse converts a KomputerSchedule CR to a ScheduleResponse.
@@ -65,6 +77,7 @@ func scheduleToResponse(s komputerv1alpha1.KomputerSchedule) ScheduleResponse {
 		Name:           s.Name,
 		Namespace:      s.Namespace,
 		Schedule:       s.Spec.Schedule,
+		Instructions:   s.Spec.Instructions,
 		Timezone:       s.Spec.Timezone,
 		AutoDelete:     s.Spec.AutoDelete,
 		KeepAgents:     s.Spec.KeepAgents,
@@ -227,6 +240,123 @@ func deleteSchedule(k8s *K8sClient) gin.HandlerFunc {
 	}
 }
 
+// triggerScheduleNow is the shared firing routine used by both the HTTP handler
+// (POST /schedules/:name/trigger) and the MCP server's trigger_schedule tool.
+// Returns (agentName, statusCode, error). statusCode mirrors HTTP semantics
+// (200 ok, 404 missing, 409 conflict, 500 internal) so callers can map naturally.
+func triggerScheduleNow(ctx context.Context, k8s *K8sClient, ns, name string) (string, int, error) {
+	schedule, err := k8s.GetSchedule(ctx, ns, name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", http.StatusNotFound, fmt.Errorf("schedule not found")
+		}
+		return "", http.StatusInternalServerError, err
+	}
+	if schedule.Status.LastRunStatus == "InProgress" {
+		return "", http.StatusConflict, fmt.Errorf("a run is already in progress")
+	}
+	agentName := schedule.Spec.AgentName
+	if agentName == "" {
+		agentName = schedule.Name + "-agent"
+	}
+
+	agent, agentErr := k8s.GetAgent(ctx, ns, agentName)
+	if agentErr != nil && !errors.IsNotFound(agentErr) {
+		return "", http.StatusInternalServerError, fmt.Errorf("failed to look up agent: %w", agentErr)
+	}
+
+	instructions := schedule.Spec.Instructions
+
+	if errors.IsNotFound(agentErr) {
+		if schedule.Spec.Agent == nil {
+			return "", http.StatusNotFound, fmt.Errorf("agent %s does not exist and schedule has no agent template", agentName)
+		}
+		lifecycle := string(schedule.Spec.Agent.Lifecycle)
+		if lifecycle == "" {
+			lifecycle = string(komputerv1alpha1.AgentLifecycleSleep)
+		}
+		_, err := k8s.CreateAgent(
+			ctx, ns, agentName,
+			instructions, "", "",
+			schedule.Spec.Agent.Model,
+			schedule.Spec.Agent.TemplateRef,
+			schedule.Spec.Agent.Role,
+			schedule.Spec.Agent.Secrets,
+			nil, nil, nil,
+			lifecycle, "", 0,
+			(*corev1.PodSpec)(nil),
+			(*komputerv1alpha1.StorageSpec)(nil),
+			map[string]string{"komputer.ai/schedule": schedule.Name},
+		)
+		if err != nil {
+			return "", http.StatusInternalServerError, fmt.Errorf("failed to create agent: %w", err)
+		}
+	} else {
+		if agent.Status.TaskStatus == komputerv1alpha1.AgentTaskInProgress {
+			return "", http.StatusConflict, fmt.Errorf("agent %s is currently busy", agentName)
+		}
+		if agent.Status.Phase == komputerv1alpha1.AgentPhaseSleeping {
+			if err := k8s.WakeAgent(ctx, ns, agentName, instructions, "", "", "", string(agent.Spec.Lifecycle)); err != nil {
+				return "", http.StatusInternalServerError, fmt.Errorf("failed to wake agent: %w", err)
+			}
+		} else if agent.Status.PodName != "" {
+			if _, err := k8s.ForwardTaskToAgent(ctx, ns, agent.Status.PodName, agentName, instructions, "", "", ""); err != nil {
+				return "", http.StatusInternalServerError, fmt.Errorf("failed to forward task: %w", err)
+			}
+		} else {
+			return "", http.StatusConflict, fmt.Errorf("agent %s has no running pod", agentName)
+		}
+	}
+
+	now := metav1.NewTime(time.Now().UTC())
+	if freshSchedule, getErr := k8s.GetSchedule(ctx, ns, name); getErr == nil {
+		original := freshSchedule.DeepCopy()
+		freshSchedule.Status.LastRunTime = &now
+		freshSchedule.Status.RunCount++
+		freshSchedule.Status.LastRunStatus = "InProgress"
+		freshSchedule.Status.AgentName = agentName
+		if patchErr := k8s.PatchScheduleStatus(ctx, original, freshSchedule); patchErr != nil {
+			Logger.Warnw("manual trigger: failed to update schedule status", "schedule", name, "error", patchErr)
+		}
+	}
+
+	return agentName, http.StatusOK, nil
+}
+
+// triggerSchedule fires a schedule immediately, outside of its cron cadence.
+// Mirrors the operator's reconcile-time fire path: ensures the agent exists (creating
+// from spec.Agent template if needed), then wakes or forwards the task. Updates the
+// schedule status the same way the operator would.
+// @ID triggerSchedule
+// @Summary Trigger schedule now
+// @Description Fires the schedule immediately, independent of its cron cadence. Returns 409 if a run is already in progress.
+// @Tags schedules
+// @Produce json
+// @Param name path string true "Schedule name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Success 200 {object} TriggerScheduleResponse "Triggered"
+// @Failure 404 {object} map[string]string "Schedule not found"
+// @Failure 409 {object} map[string]string "A run is already in progress"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /schedules/{name}/trigger [post]
+func triggerSchedule(k8s *K8sClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		name := c.Param("name")
+		ns := resolveNamespace(c, k8s)
+		agentName, statusCode, err := triggerScheduleNow(c.Request.Context(), k8s, ns, name)
+		if err != nil {
+			c.JSON(statusCode, gin.H{"error": err.Error()})
+			return
+		}
+		Logger.Infow("manual trigger fired schedule", "namespace", ns, "schedule", name, "agent", agentName)
+		c.JSON(http.StatusOK, TriggerScheduleResponse{
+			Status:    "triggered",
+			Name:      name,
+			AgentName: agentName,
+		})
+	}
+}
+
 // patchSchedule updates the cron expression for a schedule.
 // @ID patchSchedule
 // @Summary Patch schedule
@@ -250,11 +380,11 @@ func patchSchedule(k8s *K8sClient) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
 			return
 		}
-		if req.Schedule == nil {
+		if req.Schedule == nil && req.Instructions == nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no fields to update"})
 			return
 		}
-		if err := k8s.PatchScheduleCron(c.Request.Context(), ns, name, *req.Schedule); err != nil {
+		if err := k8s.PatchScheduleSpec(c.Request.Context(), ns, name, req.Schedule, req.Instructions); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to patch schedule: " + err.Error()})
 			return
 		}

--- a/komputer-api/k8s.go
+++ b/komputer-api/k8s.go
@@ -847,17 +847,36 @@ func (k *K8sClient) GetSchedule(ctx context.Context, ns, name string) (*komputer
 }
 
 func (k *K8sClient) PatchScheduleCron(ctx context.Context, ns, name, cron string) error {
+	return k.PatchScheduleSpec(ctx, ns, name, &cron, nil)
+}
+
+// PatchScheduleSpec patches mutable spec fields (cron expression, instructions) on a schedule.
+// nil pointers are skipped.
+func (k *K8sClient) PatchScheduleSpec(ctx context.Context, ns, name string, cron, instructions *string) error {
 	schedule := &komputerv1alpha1.KomputerSchedule{}
 	key := types.NamespacedName{Name: name, Namespace: ns}
 	if err := k.client.Get(ctx, key, schedule); err != nil {
 		return fmt.Errorf("failed to get schedule %s: %w", name, err)
 	}
-	if schedule.Spec.Schedule == cron {
+	original := schedule.DeepCopy()
+	changed := false
+	if cron != nil && schedule.Spec.Schedule != *cron {
+		schedule.Spec.Schedule = *cron
+		changed = true
+	}
+	if instructions != nil && schedule.Spec.Instructions != *instructions {
+		schedule.Spec.Instructions = *instructions
+		changed = true
+	}
+	if !changed {
 		return nil
 	}
-	original := schedule.DeepCopy()
-	schedule.Spec.Schedule = cron
 	return k.client.Patch(ctx, schedule, client.MergeFrom(original))
+}
+
+// PatchScheduleStatus applies a status subresource patch built from (original -> updated).
+func (k *K8sClient) PatchScheduleStatus(ctx context.Context, original, updated *komputerv1alpha1.KomputerSchedule) error {
+	return k.client.Status().Patch(ctx, updated, client.MergeFrom(original))
 }
 
 func (k *K8sClient) ListSchedules(ctx context.Context, ns string) ([]komputerv1alpha1.KomputerSchedule, error) {

--- a/komputer-api/mcp_server.go
+++ b/komputer-api/mcp_server.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newMCPServer builds the komputer-ai MCP server: exposes the highest-leverage
+// API capabilities to external Claude / Claude-Code / MCP-aware agents as tools.
+// Each tool wraps an existing handler-layer operation via the shared K8sClient.
+func newMCPServer(k8s *K8sClient) *mcp.Server {
+	srv := mcp.NewServer(&mcp.Implementation{
+		Name:    "komputer-ai",
+		Version: "v1",
+	}, nil)
+
+	registerAgentMCPTools(srv, k8s)
+	registerScheduleMCPTools(srv, k8s)
+	registerMemoryMCPTools(srv, k8s)
+	registerSkillMCPTools(srv, k8s)
+	registerConnectorMCPTools(srv, k8s)
+	registerSecretMCPTools(srv, k8s)
+	registerInfraMCPTools(srv, k8s)
+
+	return srv
+}
+
+// mountMCPHandler installs the MCP streamable HTTP endpoint on the Gin router.
+// External agents connect by adding a custom MCP connector pointing at <api-url>/mcp.
+// No auth: matches the existing API posture; network access controls are assumed.
+func mountMCPHandler(r *gin.Engine, k8s *K8sClient) {
+	srv := newMCPServer(k8s)
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return srv
+	}, nil)
+	r.Any("/mcp", gin.WrapH(handler))
+	r.Any("/mcp/*any", gin.WrapH(handler))
+}
+
+// ─── Agents ───────────────────────────────────────────────────────────────
+
+type listAgentsArgs struct {
+	Namespace string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace; empty = all namespaces"`
+}
+
+type getAgentArgs struct {
+	Name      string `json:"name" jsonschema:"Agent name"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace"`
+}
+
+func registerAgentMCPTools(srv *mcp.Server, k8s *K8sClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_agents",
+		Description: "List KomputerAgent resources in a namespace (or all namespaces if omitted). Returns name, phase, model, and task status for each.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listAgentsArgs) (*mcp.CallToolResult, any, error) {
+		agents, err := k8s.ListAgents(ctx, args.Namespace, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		out := make([]map[string]any, 0, len(agents))
+		for _, a := range agents {
+			out = append(out, map[string]any{
+				"name":       a.Name,
+				"namespace":  a.Namespace,
+				"phase":      string(a.Status.Phase),
+				"taskStatus": string(a.Status.TaskStatus),
+				"model":      a.Spec.Model,
+				"lifecycle":  string(a.Spec.Lifecycle),
+			})
+		}
+		return nil, map[string]any{"agents": out}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "get_agent",
+		Description: "Get full details for a single KomputerAgent: spec, status, current task message, and recent costs.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getAgentArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		a, err := k8s.GetAgent(ctx, ns, args.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, map[string]any{
+			"name":            a.Name,
+			"namespace":       a.Namespace,
+			"phase":           string(a.Status.Phase),
+			"taskStatus":      string(a.Status.TaskStatus),
+			"lastTaskMessage": a.Status.LastTaskMessage,
+			"model":           a.Spec.Model,
+			"lifecycle":       string(a.Spec.Lifecycle),
+			"instructions":    a.Spec.Instructions,
+			"memories":        a.Spec.Memories,
+			"skills":          a.Spec.Skills,
+			"connectors":      a.Spec.Connectors,
+			"totalCostUSD":    a.Status.TotalCostUSD,
+			"lastTaskCostUSD": a.Status.LastTaskCostUSD,
+		}, nil
+	})
+}
+
+// ─── Schedules ────────────────────────────────────────────────────────────
+
+type scheduleNameArgs struct {
+	Name      string `json:"name" jsonschema:"Schedule name"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace"`
+}
+
+type listSchedulesArgs struct {
+	Namespace string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace; empty = all namespaces"`
+}
+
+func registerScheduleMCPTools(srv *mcp.Server, k8s *K8sClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_schedules",
+		Description: "List KomputerSchedule resources. Each schedule fires its agent on a cron cadence with a fixed instructions payload.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listSchedulesArgs) (*mcp.CallToolResult, any, error) {
+		schedules, err := k8s.ListSchedules(ctx, args.Namespace)
+		if err != nil {
+			return nil, nil, err
+		}
+		out := make([]ScheduleResponse, 0, len(schedules))
+		for _, s := range schedules {
+			out = append(out, scheduleToResponse(s))
+		}
+		return nil, map[string]any{"schedules": out}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "get_schedule",
+		Description: "Get full details for a single KomputerSchedule including the instructions it runs each tick.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args scheduleNameArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		s, err := k8s.GetSchedule(ctx, ns, args.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, scheduleToResponse(*s), nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "trigger_schedule",
+		Description: "Fire a schedule immediately, outside its cron cadence. The schedule's normal next run remains scheduled.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args scheduleNameArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		agentName, _, err := triggerScheduleNow(ctx, k8s, ns, args.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, map[string]any{
+			"status":    "triggered",
+			"name":      args.Name,
+			"agentName": agentName,
+		}, nil
+	})
+}
+
+// ─── Memories ─────────────────────────────────────────────────────────────
+
+type memoryNameArgs struct {
+	Name      string `json:"name" jsonschema:"Memory name"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace"`
+}
+
+type listMemoriesArgs struct {
+	Namespace string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace; empty = current"`
+}
+
+func registerMemoryMCPTools(srv *mcp.Server, k8s *K8sClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_memories",
+		Description: "List KomputerMemory resources (reusable knowledge blocks that agents can attach to their system prompt).",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listMemoriesArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		mems, err := k8s.ListMemories(ctx, ns)
+		if err != nil {
+			return nil, nil, err
+		}
+		out := make([]map[string]any, 0, len(mems))
+		for _, m := range mems {
+			out = append(out, map[string]any{
+				"name":        m.Name,
+				"namespace":   m.Namespace,
+				"description": m.Spec.Description,
+			})
+		}
+		return nil, map[string]any{"memories": out}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "get_memory",
+		Description: "Get a single memory's content and description.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args memoryNameArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		m, err := k8s.GetMemory(ctx, ns, args.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, map[string]any{
+			"name":        m.Name,
+			"namespace":   m.Namespace,
+			"description": m.Spec.Description,
+			"content":     m.Spec.Content,
+		}, nil
+	})
+}
+
+// ─── Skills ───────────────────────────────────────────────────────────────
+
+type skillNameArgs struct {
+	Name      string `json:"name" jsonschema:"Skill name"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace"`
+}
+
+func registerSkillMCPTools(srv *mcp.Server, k8s *K8sClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_skills",
+		Description: "List KomputerSkill resources (reusable scripts/tools agents can invoke).",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listMemoriesArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		skills, err := k8s.ListSkills(ctx, ns)
+		if err != nil {
+			return nil, nil, err
+		}
+		out := make([]map[string]any, 0, len(skills))
+		for _, s := range skills {
+			out = append(out, map[string]any{
+				"name":        s.Name,
+				"namespace":   s.Namespace,
+				"description": s.Spec.Description,
+			})
+		}
+		return nil, map[string]any{"skills": out}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "get_skill",
+		Description: "Get a single skill's full body and description.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args skillNameArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		s, err := k8s.GetSkill(ctx, ns, args.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, map[string]any{
+			"name":        s.Name,
+			"namespace":   s.Namespace,
+			"description": s.Spec.Description,
+			"body":        s.Spec.Content,
+		}, nil
+	})
+}
+
+// ─── Connectors ───────────────────────────────────────────────────────────
+
+func registerConnectorMCPTools(srv *mcp.Server, k8s *K8sClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_connectors",
+		Description: "List KomputerConnector resources (configured external MCP servers like GitHub, Slack, Atlassian).",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listMemoriesArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		conns, err := k8s.ListConnectors(ctx, ns)
+		if err != nil {
+			return nil, nil, err
+		}
+		out := make([]map[string]any, 0, len(conns))
+		for _, c := range conns {
+			out = append(out, map[string]any{
+				"name":      c.Name,
+				"namespace": c.Namespace,
+				"type":      c.Spec.Type,
+				"url":       c.Spec.URL,
+			})
+		}
+		return nil, map[string]any{"connectors": out}, nil
+	})
+}
+
+// ─── Secrets ──────────────────────────────────────────────────────────────
+
+func registerSecretMCPTools(srv *mcp.Server, k8s *K8sClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_secrets",
+		Description: "List K8s Secret names visible in a namespace (values are never returned).",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listMemoriesArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		secrets, err := k8s.ListSecrets(ctx, ns, false)
+		if err != nil {
+			return nil, nil, err
+		}
+		out := make([]map[string]any, 0, len(secrets))
+		for _, s := range secrets {
+			keys := make([]string, 0, len(s.Data))
+			for k := range s.Data {
+				keys = append(keys, k)
+			}
+			out = append(out, map[string]any{
+				"name":      s.Name,
+				"namespace": s.Namespace,
+				"keys":      keys,
+			})
+		}
+		return nil, map[string]any{"secrets": out}, nil
+	})
+}
+
+// ─── Infrastructure ──────────────────────────────────────────────────────
+
+func registerInfraMCPTools(srv *mcp.Server, k8s *K8sClient) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_namespaces",
+		Description: "List Kubernetes namespaces visible to komputer-api.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		ns, err := k8s.ListNamespaces(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, map[string]any{"namespaces": ns}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_templates",
+		Description: "List available KomputerAgentTemplate / KomputerAgentClusterTemplate resources.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listMemoriesArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		templates, err := k8s.ListTemplates(ctx, ns)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, map[string]any{"templates": templates}, nil
+	})
+}

--- a/komputer-api/routes.go
+++ b/komputer-api/routes.go
@@ -61,6 +61,9 @@ func SetupRoutes(r *gin.Engine, k8s *K8sClient, hub *Hub, worker *RedisWorker) {
 		c.JSON(http.StatusOK, gin.H{"status": "ready"})
 	})
 
+	// MCP server — exposes capabilities to external Claude/MCP-aware agents at /mcp.
+	mountMCPHandler(r, k8s)
+
 	v1 := r.Group("/api/v1")
 	{
 		v1.POST("/agents", createOrTriggerAgent(k8s))
@@ -93,6 +96,7 @@ func SetupRoutes(r *gin.Engine, k8s *K8sClient, hub *Hub, worker *RedisWorker) {
 		v1.GET("/schedules/:name", getSchedule(k8s))
 		v1.DELETE("/schedules/:name", deleteSchedule(k8s))
 		v1.PATCH("/schedules/:name", patchSchedule(k8s))
+		v1.POST("/schedules/:name/trigger", triggerSchedule(k8s))
 
 		v1.POST("/memories", createMemory(k8s))
 		v1.GET("/memories", listMemories(k8s))

--- a/komputer-cli/cmd_schedules.go
+++ b/komputer-cli/cmd_schedules.go
@@ -191,6 +191,9 @@ func registerScheduleCommands(root *cobra.Command) {
 			row("Timezone:", sched.Timezone)
 			row("Phase:", phaseBadge)
 			row("Agent:", sched.AgentName)
+			if sched.Instructions != "" {
+				row("Instructions:", sched.Instructions)
+			}
 
 			if sched.NextRunTime != "" {
 				row("Next Run:", sched.NextRunTime)
@@ -382,6 +385,108 @@ func registerScheduleCommands(root *cobra.Command) {
 			fmt.Println(successStyle.Render(fmt.Sprintf("✔ Schedule %q deleted", scheduleName)))
 		},
 	})
+
+	// ── schedule trigger ───────────────────────────────────────────────
+	scheduleCmd.AddCommand(&cobra.Command{
+		Use:   "trigger <name>",
+		Short: "Trigger a schedule to run now (outside of its cron cadence)",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			ep := resolveEndpoint(cmd)
+			scheduleName := args[0]
+
+			data, status, err := apiRequest("POST", fmt.Sprintf("%s/api/v1/schedules/%s/trigger%s", ep, url.PathEscape(scheduleName), nsQuery(cmd)), nil)
+			if err != nil {
+				if jsonMode {
+					dieJSON("Request failed: "+err.Error(), 0)
+				}
+				fmt.Println(errorStyle.Render("Request failed: " + err.Error()))
+				os.Exit(1)
+			}
+			if status == 404 {
+				if jsonMode {
+					dieJSON(fmt.Sprintf("Schedule %q not found", scheduleName), 404)
+				}
+				fmt.Println(errorStyle.Render(fmt.Sprintf("Schedule %q not found", scheduleName)))
+				os.Exit(1)
+			}
+			if status == 409 {
+				var errResp ErrorResponse
+				json.Unmarshal(data, &errResp)
+				if jsonMode {
+					dieJSON(errResp.Error, 409)
+				}
+				fmt.Println(warnStyle.Render("⚠ " + errResp.Error))
+				os.Exit(1)
+			}
+			if status != 200 {
+				if jsonMode {
+					dieJSON(fmt.Sprintf("API error (%d): %s", status, string(data)), status)
+				}
+				fmt.Println(errorStyle.Render(fmt.Sprintf("API error (%d): %s", status, string(data))))
+				os.Exit(1)
+			}
+			if jsonMode {
+				printJSON(json.RawMessage(data))
+				return
+			}
+			fmt.Println(successStyle.Render(fmt.Sprintf("✔ Schedule %q triggered", scheduleName)))
+		},
+	})
+
+	// ── schedule update ────────────────────────────────────────────────
+	scheduleUpdateCmd := &cobra.Command{
+		Use:   "update <name>",
+		Short: "Update a schedule's cron expression or instructions",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			ep := resolveEndpoint(cmd)
+			scheduleName := args[0]
+			cron, _ := cmd.Flags().GetString("cron")
+			instructions, _ := cmd.Flags().GetString("instructions")
+			if cron == "" && instructions == "" {
+				if jsonMode {
+					dieJSON("must pass --cron and/or --instructions", 400)
+				}
+				fmt.Println(errorStyle.Render("must pass --cron and/or --instructions"))
+				os.Exit(1)
+			}
+			body := map[string]interface{}{}
+			if cron != "" {
+				body["schedule"] = cron
+			}
+			if instructions != "" {
+				body["instructions"] = instructions
+			}
+			data, status, err := apiRequest("PATCH", fmt.Sprintf("%s/api/v1/schedules/%s%s", ep, url.PathEscape(scheduleName), nsQuery(cmd)), body)
+			if err != nil {
+				if jsonMode {
+					dieJSON("Request failed: "+err.Error(), 0)
+				}
+				fmt.Println(errorStyle.Render("Request failed: " + err.Error()))
+				os.Exit(1)
+			}
+			if status != 200 {
+				if jsonMode {
+					dieJSON(fmt.Sprintf("API error (%d): %s", status, string(data)), status)
+				}
+				fmt.Println(errorStyle.Render(fmt.Sprintf("API error (%d): %s", status, string(data))))
+				os.Exit(1)
+			}
+			var sched ScheduleResponse
+			json.Unmarshal(data, &sched)
+			if jsonMode {
+				printJSON(sched)
+				return
+			}
+			fmt.Println(successStyle.Render(fmt.Sprintf("✔ Schedule %q updated", scheduleName)))
+		},
+	}
+	scheduleUpdateCmd.Flags().String("cron", "", "New cron expression")
+	scheduleUpdateCmd.Flags().String("instructions", "", "New instructions for the agent")
+	scheduleCmd.AddCommand(scheduleUpdateCmd)
 
 	root.AddCommand(scheduleCmd)
 }

--- a/komputer-cli/types.go
+++ b/komputer-cli/types.go
@@ -62,6 +62,7 @@ type ScheduleResponse struct {
 	Name           string `json:"name"`
 	Namespace      string `json:"namespace"`
 	Schedule       string `json:"schedule"`
+	Instructions   string `json:"instructions"`
 	Timezone       string `json:"timezone"`
 	AutoDelete     bool   `json:"autoDelete"`
 	KeepAgents     bool   `json:"keepAgents"`

--- a/komputer-ui/src/app/schedules/[name]/page.tsx
+++ b/komputer-ui/src/app/schedules/[name]/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
-import { Trash2, Calendar, CheckCircle, DollarSign, Activity, Pencil, Check, X, Clock } from "lucide-react";
+import { Trash2, Calendar, CheckCircle, DollarSign, Activity, Pencil, Check, X, Clock, Play } from "lucide-react";
 
 import { Button } from "@/components/kit/button";
 import { Badge } from "@/components/kit/badge";
@@ -14,7 +14,7 @@ import { RelativeTime } from "@/components/shared/relative-time";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
 import { SkeletonTable } from "@/components/shared/loading-skeleton";
 import { Input } from "@/components/kit/input";
-import { getSchedule, deleteSchedule, patchSchedule } from "@/lib/api";
+import { getSchedule, deleteSchedule, patchSchedule, triggerSchedule } from "@/lib/api";
 import { useDelayedLoading } from "@/hooks/use-delayed-loading";
 import { cronToHuman, formatCost } from "@/lib/utils";
 import type { ScheduleResponse } from "@/lib/types";
@@ -55,6 +55,11 @@ export default function ScheduleDetailPage() {
   const [editingCron, setEditingCron] = useState(false);
   const [cronDraft, setCronDraft] = useState("");
   const [savingCron, setSavingCron] = useState(false);
+  const [editingInstructions, setEditingInstructions] = useState(false);
+  const [instructionsDraft, setInstructionsDraft] = useState("");
+  const [savingInstructions, setSavingInstructions] = useState(false);
+  const [triggering, setTriggering] = useState(false);
+  const [triggerMessage, setTriggerMessage] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
     try {
@@ -100,6 +105,40 @@ export default function ScheduleDetailPage() {
       // keep editing on error
     } finally {
       setSavingCron(false);
+    }
+  }
+
+  async function handleSaveInstructions() {
+    const trimmed = instructionsDraft.trim();
+    if (!trimmed || trimmed === schedule?.instructions) {
+      setEditingInstructions(false);
+      return;
+    }
+    setSavingInstructions(true);
+    try {
+      await patchSchedule(name, { instructions: trimmed }, scheduleNs);
+      await fetchData();
+      setEditingInstructions(false);
+    } catch {
+      // keep editing on error
+    } finally {
+      setSavingInstructions(false);
+    }
+  }
+
+  async function handleTrigger() {
+    setTriggering(true);
+    setTriggerMessage(null);
+    try {
+      await triggerSchedule(name, scheduleNs);
+      setTriggerMessage("Schedule triggered.");
+      await fetchData();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Failed to trigger";
+      setTriggerMessage(msg);
+    } finally {
+      setTriggering(false);
+      window.setTimeout(() => setTriggerMessage(null), 4000);
     }
   }
 
@@ -164,7 +203,26 @@ export default function ScheduleDetailPage() {
               one-time
             </Badge>
           )}
-          <div className="ml-auto">
+          <div className="ml-auto flex items-center gap-2">
+            {triggerMessage && (
+              <span className="text-xs text-[var(--color-text-secondary)]">{triggerMessage}</span>
+            )}
+            <ConfirmDialog
+              title={`Run ${schedule.name} now?`}
+              description="This triggers the schedule's instructions immediately, outside of its cron cadence."
+              onConfirm={handleTrigger}
+              trigger={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={triggering || schedule.lastRunStatus === "InProgress"}
+                  title={schedule.lastRunStatus === "InProgress" ? "A run is already in progress" : undefined}
+                >
+                  <Play className="size-3.5 text-[var(--color-brand-blue)]" />
+                  {triggering ? "Triggering..." : "Run now"}
+                </Button>
+              }
+            />
             <ConfirmDialog
               title={`Delete ${schedule.name}?`}
               description="This will permanently delete this schedule. This action cannot be undone."
@@ -253,6 +311,69 @@ export default function ScheduleDetailPage() {
             </AnimatePresence>
           </div>
         </div>
+
+        {/* Instructions */}
+        <section>
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
+              Instructions
+            </h2>
+            {!editingInstructions && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setInstructionsDraft(schedule.instructions ?? "");
+                  setEditingInstructions(true);
+                }}
+              >
+                <Pencil className="size-3 text-[var(--color-text-muted)]" />
+                Edit
+              </Button>
+            )}
+          </div>
+          {editingInstructions ? (
+            <div className="space-y-2">
+              <textarea
+                value={instructionsDraft}
+                onChange={(e) => setInstructionsDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") setEditingInstructions(false);
+                }}
+                className="w-full min-h-[120px] rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-brand-blue)] resize-y"
+                placeholder="What should the agent do each run?"
+                autoFocus
+                disabled={savingInstructions}
+              />
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleSaveInstructions}
+                  disabled={savingInstructions}
+                >
+                  <Check className="size-3.5" />
+                  {savingInstructions ? "Saving..." : "Save"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setEditingInstructions(false)}
+                  disabled={savingInstructions}
+                >
+                  <X className="size-3.5" />
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] whitespace-pre-wrap">
+              {schedule.instructions || (
+                <span className="text-[var(--color-text-muted)] italic">No instructions set.</span>
+              )}
+            </div>
+          )}
+        </section>
 
         {/* Stats cards */}
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/komputer-ui/src/components/agents/agent-chat.tsx
+++ b/komputer-ui/src/components/agents/agent-chat.tsx
@@ -236,6 +236,14 @@ function formatTimestamp(ts: string): string {
   return `${d.toLocaleDateString([], dateOpts)}, ${time}`;
 }
 
+function formatThinkingDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}m ${s}s`;
+}
+
 function formatTokenCount(n: number): string {
   if (n >= 1_000_000) {
     const v = n / 1_000_000;
@@ -1157,6 +1165,32 @@ export function AgentChat({
 
   const showThinking = isWorking && !cancelling;
 
+  const thinkingStartMs = useMemo(() => {
+    if (!showThinking) return null;
+    for (let i = events.length - 1; i >= 0; i--) {
+      const t = events[i].type;
+      if (t === "task_completed" || t === "task_cancelled" || t === "error") break;
+      if (t === "task_started" || t === "thinking") {
+        const parsed = Date.parse(events[i].timestamp);
+        if (!Number.isNaN(parsed)) return parsed;
+      }
+    }
+    const parsed = Date.parse(pendingTimestamp);
+    return Number.isNaN(parsed) ? Date.now() : parsed;
+  }, [showThinking, events, pendingTimestamp]);
+
+  const [thinkingElapsedMs, setThinkingElapsedMs] = useState(0);
+  useEffect(() => {
+    if (!showThinking || thinkingStartMs == null) {
+      setThinkingElapsedMs(0);
+      return;
+    }
+    const tick = () => setThinkingElapsedMs(Math.max(0, Date.now() - thinkingStartMs));
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, [showThinking, thinkingStartMs]);
+
   // Track if user is scrolled away from the bottom
   const [showScrollDown, setShowScrollDown] = useState(false);
   useEffect(() => {
@@ -1235,6 +1269,11 @@ export function AgentChat({
                 </div>
                 <span className="text-xs text-[var(--color-brand-violet-light)]">
                   Thinking
+                  {thinkingStartMs != null && (
+                    <span className="ml-1.5 opacity-70 tabular-nums">
+                      · {formatThinkingDuration(thinkingElapsedMs)}
+                    </span>
+                  )}
                 </span>
               </motion.div>
             )}

--- a/komputer-ui/src/lib/api.ts
+++ b/komputer-ui/src/lib/api.ts
@@ -122,8 +122,14 @@ export const createSchedule = (data: CreateScheduleRequest) =>
 export const deleteSchedule = (name: string, ns?: string) =>
   request<void>(`/schedules/${name}${ns ? `?namespace=${ns}` : ''}`, { method: 'DELETE' });
 
-export const patchSchedule = (name: string, data: { schedule?: string }, ns?: string) =>
+export const patchSchedule = (name: string, data: { schedule?: string; instructions?: string }, ns?: string) =>
   request<ScheduleResponse>(`/schedules/${name}${ns ? `?namespace=${ns}` : ''}`, { method: 'PATCH', body: JSON.stringify(data) });
+
+export const triggerSchedule = (name: string, ns?: string) =>
+  request<{ status: string; name: string; agentName: string }>(
+    `/schedules/${name}/trigger${ns ? `?namespace=${ns}` : ''}`,
+    { method: 'POST' }
+  );
 
 // Agent settings
 export const patchAgent = (name: string, data: PatchAgentRequest, ns?: string) =>

--- a/komputer-ui/src/lib/types.ts
+++ b/komputer-ui/src/lib/types.ts
@@ -69,6 +69,7 @@ export interface ScheduleResponse {
   name: string;
   namespace: string;
   schedule: string;
+  instructions: string;
   timezone?: string;
   autoDelete?: boolean;
   keepAgents?: boolean;


### PR DESCRIPTION
## Summary
- **Thinking indicator counter** — UI now shows elapsed seconds/minutes next to "Thinking" so long-running tasks read as alive instead of stuck
- **Schedule manual trigger + visible instructions** — schedule detail page shows/edits the instructions; new "Run now" button + `POST /schedules/{name}/trigger` API + `komputer schedule trigger` CLI + `trigger_schedule` manager MCP tool
- **Built-in MCP server** — `komputer-api` now serves a streamable-HTTP MCP endpoint at `/mcp` exposing 13 tools (agents, schedules, memories, skills, connectors, secrets, infra) for external Claude / MCP-aware clients
- **Docs** — every core concept (templates, schedules, squads, offices, config, connectors) now has at least one full YAML + curl example; new `integration/mcp-server.md` page explicitly documents the `<api-base-url>/mcp` path users must configure

## Test plan
- [ ] Smoke-test in UI: open a long-running agent and confirm the "Thinking · Ns" counter ticks up; resets between tasks
- [ ] Smoke-test in UI: open a schedule, edit instructions, save, then click "Run now" and confirm an agent fires
- [ ] Curl `POST /api/v1/schedules/<name>/trigger` and confirm `200` + a new agent run; second call while in-progress returns `409`
- [ ] Point Claude Code at `<api-url>/mcp` as a custom connector and confirm `tools/list` shows 13 tools and `list_schedules`/`list_namespaces` return real data
- [ ] Run `komputer schedule trigger <name>` and `komputer schedule update <name> --instructions "..."` against a live API
- [ ] `helm template` + `helm install --dry-run` the chart (no chart changes here but worth a sanity check)
- [ ] Render docs site and confirm Schedules, Templates, Squads, Offices, Config, Connectors, and the new MCP Server page all show YAML/curl blocks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)