### PR TITLE
feat: manual compaction across UI/API/CLI/MCP with persistent Compacting status

### DIFF
--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -90,3 +90,27 @@ kubectl get komputeragents -o custom-columns=NAME:.metadata.name,PHASE:.status.p
 # vc-3    Queued   1      template "default" reached maxConcurrentAgents (1/1 running)
 # vc-2    Queued   2      template "default" reached maxConcurrentAgents (1/1 running)
 ```
+
+## Compaction
+
+When an agent's conversation history fills its model context window, the bundled Claude Code CLI **automatically compacts** the older turns into a summary — preserving recent context while freeing space to keep going. komputer-ai surfaces compaction in three ways:
+
+- The chat UI shows a purple divider (**"Context auto-compacted"** or **"Context compacted manually"**) inline with the conversation at the moment compaction happens
+- The CLI's interactive `komputer chat` prints a dim `── context auto-compacted ──` line in the same place
+- The event stream emits a `compaction` event with `payload.trigger` set to `"auto"` or `"manual"` — useful for SDK consumers building custom dashboards
+
+### Manual compaction
+
+You can trigger compaction yourself while an agent is actively running a task. This is useful when you know a long paste or tool result is about to land and you'd rather compact preemptively than wait for the auto-trigger.
+
+- **UI**: the purple Layers icon in the chat input footer, visible only while the agent is working
+- **CLI**: `komputer agent compact <name>` (optionally `--instructions "preserve all code blocks"`)
+- **REST**: `POST /api/v1/agents/<name>/compact` with optional `{"instructions": "..."}`
+- **Manager MCP tool**: `compact_agent` (one of the manager tools a manager agent has access to)
+- **External MCP**: the API's `/mcp` endpoint exposes `compact_agent` to external Claude / MCP-aware clients
+
+Manual compaction only works while the agent is **actively running a task** — there's no conversation to compact otherwise. The endpoint returns 409 if the agent is idle.
+
+### Where to tune compaction
+
+There's no UI knob yet for the auto-compaction threshold or strategy — those stay at the bundled Claude Code CLI's defaults (compaction triggers around 95% of the model's context window). A future release may expose them as `KomputerAgentSpec` fields.

--- a/docs/integration/mcp-server.md
+++ b/docs/integration/mcp-server.md
@@ -68,6 +68,7 @@ The current tool set is focused on the most useful remote-control surface. All t
 |------|---------|
 | `list_agents` | List agents in a namespace (or all namespaces) |
 | `get_agent` | Full spec + status + costs for one agent |
+| `compact_agent` | Trigger manual conversation compaction on an agent's active task |
 | `list_schedules` | List schedules in a namespace |
 | `get_schedule` | Full schedule including current `instructions` |
 | `trigger_schedule` | Fire a schedule immediately, outside its cron cadence |

--- a/docs/integration/rest-api.md
+++ b/docs/integration/rest-api.md
@@ -105,6 +105,28 @@ POST /api/v1/agents/:name/cancel?namespace=production
 
 Gracefully cancels the running task. The agent pod stays alive for future tasks.
 
+## Compact a Conversation
+
+Manually trigger compaction on the agent's active task. Older turns are summarized to free context space. Only works while the agent is actively running a task — returns `409 Conflict` otherwise.
+
+```
+POST /api/v1/agents/:name/compact?namespace=production
+Content-Type: application/json
+```
+
+The body is optional. If you want to guide the compactor:
+
+```json
+{ "instructions": "preserve all code blocks and recent file paths" }
+```
+
+**Response (200 OK):**
+```json
+{ "status": "compacting", "name": "my-agent" }
+```
+
+When the compaction actually happens, a `compaction` event is emitted on the agent's event stream with `payload.trigger = "manual"`. See [Agents → Compaction](../concepts/agents.md#compaction) for the full picture.
+
 ## Delete an Agent
 
 ```

--- a/komputer-agent/agent.py
+++ b/komputer-agent/agent.py
@@ -110,6 +110,11 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
         "model": model,
     })
 
+    # Tracks the most recent AssistantMessage usage so the PreCompact hook can
+    # publish a snapshot of context size at compaction time. Updated in
+    # process_responses below; read inside pre_compact_hook via closure.
+    last_usage = None
+
     async def post_tool_hook(input, session_id, ctx):
         publisher.publish(
             "tool_result",
@@ -123,12 +128,26 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
 
     async def pre_compact_hook(input, session_id, ctx):
         # Fires right before Claude Code auto- or manually-compacts the conversation.
-        # Surface it as an event so the UI can render a divider with context.
+        # Snapshot the current context size from the most recent AssistantMessage.usage
+        # so the UI can render a before -> after picture once compaction completes.
+        # When the agent has no in-session usage yet (standalone-spawn /compact path),
+        # fall back to the seed value the /compact endpoint stashed from the CR.
+        import state as _state
+        tokens_before = 0
+        if last_usage:
+            for key in ("input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"):
+                v = last_usage.get(key) if isinstance(last_usage, dict) else getattr(last_usage, key, None)
+                if isinstance(v, (int, float)):
+                    tokens_before += int(v)
+        if tokens_before == 0 and isinstance(_state.compaction_prev_tokens, int) and _state.compaction_prev_tokens > 0:
+            tokens_before = _state.compaction_prev_tokens
+        _state.compaction_prev_tokens = None  # one-shot
         publisher.publish(
             "compaction",
             {
                 "trigger": input.get("trigger", "auto"),
                 "custom_instructions": input.get("custom_instructions") or "",
+                "tokens_before": tokens_before,
             },
         )
         return {}
@@ -219,7 +238,6 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
     state.steer_queue = session_steer_queue
 
     result = None
-    last_usage = None
 
     async def process_responses(client):
         """Read all responses until ResultMessage, publishing events along the way."""

--- a/komputer-agent/manager_tools.py
+++ b/komputer-agent/manager_tools.py
@@ -200,6 +200,26 @@ async def cancel_agent(args):
 
 
 @tool(
+    name="compact_agent",
+    description="Trigger manual conversation compaction on a sub-agent's active task. Older turns are summarized to free context space. Use when a sub-agent is approaching its context window and you want to keep it on the same task without restarting. Only works while the sub-agent is actively running a task. Optional `instructions` lets you guide the compactor (e.g. 'preserve all code blocks').",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "The sub-agent name (as passed to create_agent)"},
+            "instructions": {"type": "string", "description": "Optional guidance to the compactor about what to preserve."},
+        },
+        "required": ["name"],
+    },
+)
+async def compact_agent(args):
+    full_name = _sanitize_name(args["name"])
+    payload = {}
+    if args.get("instructions"):
+        payload["instructions"] = args["instructions"]
+    return await _request("POST", f"/api/v1/agents/{full_name}/compact", timeout=15, json=payload if payload else None)
+
+
+@tool(
     name="delete_agent",
     description="Delete a sub-agent and clean up its resources. Use after collecting its results.",
     input_schema={
@@ -1311,5 +1331,5 @@ def create_manager_server():
     """Create the MCP server with manager orchestration tools."""
     return create_sdk_mcp_server(
         name="komputer",
-        tools=[create_agent, schedule_agent, get_agent_status, get_agent_events, cancel_agent, delete_agent, delete_schedule, trigger_schedule, list_schedules, get_schedule, update_schedule, create_memory, attach_memory, create_skill, attach_skill, update_agent, sleep_agent, wake_agent, list_agents, patch_agent, get_agent, list_connectors, list_connector_templates, get_connector, attach_connector, detach_connector, list_secrets, create_secret, delete_secret, attach_secret, detach_secret, list_skills, get_skill, update_skill, delete_skill, detach_skill, list_memories, get_memory, update_memory, delete_memory, detach_memory, list_namespaces, list_templates, create_squad, add_to_squad, remove_from_squad, delete_squad, list_squads],
+        tools=[create_agent, schedule_agent, get_agent_status, get_agent_events, cancel_agent, compact_agent, delete_agent, delete_schedule, trigger_schedule, list_schedules, get_schedule, update_schedule, create_memory, attach_memory, create_skill, attach_skill, update_agent, sleep_agent, wake_agent, list_agents, patch_agent, get_agent, list_connectors, list_connector_templates, get_connector, attach_connector, detach_connector, list_secrets, create_secret, delete_secret, attach_secret, detach_secret, list_skills, get_skill, update_skill, delete_skill, detach_skill, list_memories, get_memory, update_memory, delete_memory, detach_memory, list_namespaces, list_templates, create_squad, add_to_squad, remove_from_squad, delete_squad, list_squads],
     )

--- a/komputer-agent/server.py
+++ b/komputer-agent/server.py
@@ -385,6 +385,88 @@ async def cancel_task():
     return {"status": "cancelling"}
 
 
+class CompactRequest(BaseModel):
+    instructions: Optional[str] = None
+    # Seed for the PreCompact hook's tokens_before payload. The API populates it
+    # from CR.status.totalTokens — the context size at the end of the last task —
+    # so the divider can show a meaningful "before" value even when /compact
+    # is spawned as a standalone task with no prior AssistantMessage usage.
+    prev_tokens: Optional[int] = None
+
+
+@app.post("/compact")
+async def compact_task(req: CompactRequest, background_tasks: BackgroundTasks):
+    """Manually trigger conversation compaction.
+
+    Two paths:
+
+    1. Agent is busy (active task) — route `/compact` through `state.active_client.query()`.
+       The SDK queues it as a follow-up message after the current turn ends; the bundled
+       CLI parses the slash command and fires the PreCompact hook with trigger="manual".
+
+    2. Agent is idle (no task running) — start a fresh task with `/compact` as the
+       instructions. The bundled CLI processes the slash command immediately as its
+       only turn, fires the PreCompact hook, then exits the session cleanly.
+
+    Either path produces the same compaction event payload to Redis.
+    """
+    instructions = (req.instructions or "").strip()
+    slash = "/compact " + instructions if instructions else "/compact"
+
+    # Stash prev_tokens so the PreCompact hook can use it as a fallback for the
+    # tokens_before payload (used when the agent has no AssistantMessage usage
+    # to read at hook time, e.g. the standalone-spawn path below).
+    state.compaction_prev_tokens = req.prev_tokens
+
+    # Path 1: live session, queue as follow-up
+    if state.busy.locked():
+        if state.active_client is None or state.active_loop is None or state.active_loop.is_closed():
+            raise HTTPException(status_code=409, detail="Session is not yet ready to accept a compaction request")
+
+        async def _do_compact():
+            try:
+                await state.active_client.query(slash)
+            except Exception as e:
+                logger.exception("manual compaction request failed: %s", e)
+
+        try:
+            state.active_loop.call_soon_threadsafe(
+                lambda: asyncio.ensure_future(_do_compact())
+            )
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to schedule compaction: {e}")
+
+        return {"status": "compacting", "instructions": instructions or None, "mode": "queued"}
+
+    # Path 2: idle — spawn a one-shot task whose only instruction is /compact
+    from agent import run_agent
+
+    cfg = agent_config.load()
+    task_model = cfg["model"]
+
+    def run_compact_with_lock():
+        global _current_task, _current_loop
+        with state.busy:
+            loop = asyncio.new_event_loop()
+            state.active_loop = loop
+            _current_loop = loop
+            _current_task = loop.create_task(run_agent(slash, task_model, _publisher))
+            try:
+                loop.run_until_complete(_current_task)
+            except asyncio.CancelledError:
+                _publisher.publish("task_cancelled", {"reason": "Compaction cancelled"})
+            finally:
+                state.set_active_client(None)
+                state.active_loop = None
+                state.steer_queue = None
+                _current_task = None
+                _current_loop = None
+                loop.close()
+
+    background_tasks.add_task(run_compact_with_lock)
+    return {"status": "compacting", "instructions": instructions or None, "mode": "standalone"}
+
+
 @app.post("/shutdown")
 async def shutdown():
     """PreStop hook: wait for the running task to finish, cancel if it takes too long."""

--- a/komputer-agent/state.py
+++ b/komputer-agent/state.py
@@ -25,6 +25,13 @@ interrupted = False
 # task_cancelled/task_completed and proceeds directly to the steer message.
 steered = False
 
+# Seed for the PreCompact hook's tokens_before payload, used when the agent
+# spawns a fresh /compact-only task and has no in-session AssistantMessage.usage
+# to read yet. The /compact HTTP endpoint sets this from the request body's
+# prev_tokens value (the API populates it from CR.status.totalTokens). Cleared
+# after the hook reads it.
+compaction_prev_tokens: int | None = None
+
 
 def set_active_client(client):
     """Register or clear the active SDK client."""

--- a/komputer-api/handler_agents.go
+++ b/komputer-api/handler_agents.go
@@ -524,6 +524,66 @@ func deleteAgent(k8s *K8sClient, worker *RedisWorker) gin.HandlerFunc {
 	}
 }
 
+// compactAgentTask manually triggers conversation compaction on an active agent task.
+// @ID compactAgentTask
+// @Summary Compact agent conversation
+// @Description Triggers manual conversation compaction. Older turns are summarized to free context space. Requires an active task — returns 409 if the agent is idle. Optional `instructions` field passes custom guidance to the compactor.
+// @Tags agents
+// @Accept json
+// @Produce json
+// @Param name path string true "Agent name"
+// @Param namespace query string false "Kubernetes namespace"
+// @Param request body CompactAgentRequest false "Optional compaction instructions"
+// @Success 200 {object} map[string]string "Compaction triggered"
+// @Failure 404 {object} map[string]string "Agent not found"
+// @Failure 409 {object} map[string]string "Agent has no running pod or no active task"
+// @Failure 500 {object} map[string]string "Internal error"
+// @Router /agents/{name}/compact [post]
+type CompactAgentRequest struct {
+	Instructions string `json:"instructions,omitempty"`
+}
+
+func compactAgentTask(k8s *K8sClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		name := c.Param("name")
+		ns := resolveNamespace(c, k8s)
+
+		var req CompactAgentRequest
+		// Body is optional; ignore bind errors so an empty POST still works.
+		_ = c.ShouldBindJSON(&req)
+
+		agent, err := k8s.GetAgent(c.Request.Context(), ns, name)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "agent not found"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		if agent.Status.PodName == "" {
+			c.JSON(http.StatusConflict, gin.H{"error": "agent has no running pod"})
+			return
+		}
+
+		if err := k8s.CompactAgentTask(c.Request.Context(), ns, agent.Status.PodName, agent.Name, req.Instructions); err != nil {
+			agentActionsTotal.WithLabelValues("compact", "error").Inc()
+			// The agent returns 409 if no active task; surface that to the caller as 409.
+			if strings.Contains(err.Error(), "status 409") || strings.Contains(err.Error(), "No task is currently running") {
+				c.JSON(http.StatusConflict, gin.H{"error": "no active task to compact; manual compaction only works while the agent is running a task"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to compact: " + err.Error()})
+			return
+		}
+
+		Logger.Infow("triggered manual compaction on agent", "namespace", ns, "agent_name", name)
+		agentActionsTotal.WithLabelValues("compact", "success").Inc()
+		c.JSON(http.StatusOK, gin.H{"status": "compacting", "name": name})
+	}
+}
+
 // cancelAgentTask cancels the running task on an agent.
 // @ID cancelAgentTask
 // @Summary Cancel agent task

--- a/komputer-api/k8s.go
+++ b/komputer-api/k8s.go
@@ -459,6 +459,53 @@ func (k *K8sClient) CancelAgentTask(ctx context.Context, ns, podName, agentName 
 	return nil
 }
 
+// CompactAgentTask triggers a manual compaction on the agent's active session.
+// The agent forwards `/compact [instructions]` through the bundled Claude Code CLI,
+// which fires the PreCompact hook with trigger="manual".
+//
+// When the agent is idle and we're spawning a fresh /compact-only session, the
+// PreCompact hook can't see any AssistantMessage.usage (no message has been sent
+// yet), so we seed `prev_tokens` from the CR's status.totalTokens — that's the
+// context size at the end of the last completed task, which is what the SDK
+// will resume into. The agent uses it as the tokens_before payload.
+//
+// Returns an error with substring "status 409" when the agent rejected the
+// request — the HTTP handler maps that to a 409 to the caller. We have to parse
+// the curl-exec response body manually because `curl -s` succeeds on any HTTP
+// status; the in-cluster HTTP path does check the status code but the exec
+// fallback (used in LOCAL=true mode) does not.
+func (k *K8sClient) CompactAgentTask(ctx context.Context, ns, podName, agentName, instructions string) error {
+	bodyMap := map[string]interface{}{}
+	if instructions != "" {
+		bodyMap["instructions"] = instructions
+	}
+	// Seed prev_tokens from the CR's last known context size, for the idle path.
+	if agent, err := k.GetAgent(ctx, ns, agentName); err == nil && agent.Status.TotalTokens > 0 {
+		bodyMap["prev_tokens"] = agent.Status.TotalTokens
+	}
+	bodyJSON, _ := json.Marshal(bodyMap)
+	err := k.postToAgent(ctx, ns, agentName, "/compact", string(bodyJSON))
+	if err != nil {
+		// Fall back to kubectl exec. Read the response body and look for an
+		// error indicator — FastAPI's HTTPException serialises as {"detail": "..."}.
+		resp, execErr := k.execInPodCurl(ctx, ns, podName, agentName, "POST", "/compact", string(bodyJSON))
+		if execErr != nil {
+			return execErr
+		}
+		var parsed struct {
+			Detail string `json:"detail"`
+			Status string `json:"status"`
+		}
+		if jerr := json.Unmarshal(resp, &parsed); jerr == nil && parsed.Detail != "" {
+			return fmt.Errorf("agent returned status 409: %s", parsed.Detail)
+		}
+		if parsed.Status == "" {
+			return fmt.Errorf("agent returned unexpected response: %s", string(resp))
+		}
+	}
+	return nil
+}
+
 // ForwardTaskToAgent sends a task to an agent's FastAPI endpoint, falling back to kubectl exec.
 func (k *K8sClient) ForwardTaskToAgent(ctx context.Context, ns, podName, agentName, instructions, model, internalSystemPrompt, systemPrompt string) (int64, error) {
 	bodyMap := map[string]string{"instructions": instructions}

--- a/komputer-api/mcp_server.go
+++ b/komputer-api/mcp_server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -49,6 +50,12 @@ type listAgentsArgs struct {
 type getAgentArgs struct {
 	Name      string `json:"name" jsonschema:"Agent name"`
 	Namespace string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace"`
+}
+
+type compactAgentArgs struct {
+	Name         string `json:"name" jsonschema:"Agent name"`
+	Namespace    string `json:"namespace,omitempty" jsonschema:"Kubernetes namespace"`
+	Instructions string `json:"instructions,omitempty" jsonschema:"Optional guidance to the compactor about what to preserve."`
 }
 
 func registerAgentMCPTools(srv *mcp.Server, k8s *K8sClient) {
@@ -100,6 +107,30 @@ func registerAgentMCPTools(srv *mcp.Server, k8s *K8sClient) {
 			"connectors":      a.Spec.Connectors,
 			"totalCostUSD":    a.Status.TotalCostUSD,
 			"lastTaskCostUSD": a.Status.LastTaskCostUSD,
+		}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "compact_agent",
+		Description: "Trigger manual conversation compaction on an agent's active task. Older turns are summarized to free context space. Only works while the agent is actively running a task — returns an error otherwise.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args compactAgentArgs) (*mcp.CallToolResult, any, error) {
+		ns := args.Namespace
+		if ns == "" {
+			ns = k8s.defaultNamespace
+		}
+		a, err := k8s.GetAgent(ctx, ns, args.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+		if a.Status.PodName == "" {
+			return nil, nil, fmt.Errorf("agent %s has no running pod", args.Name)
+		}
+		if err := k8s.CompactAgentTask(ctx, ns, a.Status.PodName, args.Name, args.Instructions); err != nil {
+			return nil, nil, fmt.Errorf("failed to compact: %w", err)
+		}
+		return nil, map[string]any{
+			"status": "compacting",
+			"name":   args.Name,
 		}, nil
 	})
 }

--- a/komputer-api/routes.go
+++ b/komputer-api/routes.go
@@ -74,6 +74,7 @@ func SetupRoutes(r *gin.Engine, k8s *K8sClient, hub *Hub, worker *RedisWorker) {
 		v1.DELETE("/agents/:name", deleteAgent(k8s, worker))
 		v1.PATCH("/agents/:name", patchAgent(k8s))
 		v1.POST("/agents/:name/cancel", cancelAgentTask(k8s))
+		v1.POST("/agents/:name/compact", compactAgentTask(k8s))
 		v1.GET("/agents/:name/ws", HandleAgentWS(hub))
 		v1.GET("/agents/:name/download/*filepath", downloadAgentFile(k8s))
 

--- a/komputer-api/worker.go
+++ b/komputer-api/worker.go
@@ -546,6 +546,17 @@ func mapEventToTaskStatus(event AgentEvent) (taskStatus string, lastMessage stri
 	case "tool_result":
 		tool, _ := event.Payload["tool"].(string)
 		return "InProgress", truncate(fmt.Sprintf("Got result from %s", tool), 256)
+	case "compaction":
+		// "Compacting" is a transient sub-state of InProgress. The next
+		// task-progress event (text/thinking/tool_*) will flip it back to
+		// "InProgress" automatically because Redis events are processed
+		// in order on a single consumer-group worker.
+		trigger, _ := event.Payload["trigger"].(string)
+		msg := "Compacting conversation..."
+		if trigger == "manual" {
+			msg = "Compacting conversation (manual)..."
+		}
+		return "Compacting", msg
 	case "task_completed":
 		return "Complete", "Task completed"
 	case "task_cancelled":

--- a/komputer-cli/cmd_agents.go
+++ b/komputer-cli/cmd_agents.go
@@ -145,6 +145,8 @@ func registerAgentCommands(root *cobra.Command) {
 				switch task {
 				case "InProgress":
 					task = busyStyle.Render(fmt.Sprintf("%-14s", "● In Progress"))
+				case "Compacting":
+					task = warnStyle.Render(fmt.Sprintf("%-14s", "↻ Compacting"))
 				case "Complete":
 					task = idleStyle.Render(fmt.Sprintf("%-14s", "✔ Complete"))
 				case "Error":
@@ -591,6 +593,63 @@ func registerAgentCommands(root *cobra.Command) {
 			fmt.Println(warnStyle.Render(fmt.Sprintf("⚠ Cancelling task on %q", args[0])))
 		},
 	})
+
+	// ── compact ──────────────────────────────────────────────────────────
+	compactCmd := &cobra.Command{
+		Use:   "compact <name>",
+		Short: "Manually compact an agent's conversation history",
+		Long:  "Triggers a manual compaction on the agent's active task. Older turns are summarized to free context space. Optional --instructions guides the compactor on what to preserve. Only works while the agent is actively running a task.",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			ep := resolveEndpoint(cmd)
+			instructions, _ := cmd.Flags().GetString("instructions")
+
+			var body interface{}
+			if instructions != "" {
+				body = map[string]string{"instructions": instructions}
+			}
+
+			data, status, err := apiRequest("POST", fmt.Sprintf("%s/api/v1/agents/%s/compact%s", ep, url.PathEscape(args[0]), nsQuery(cmd)), body)
+			if err != nil {
+				if jsonMode {
+					dieJSON("Request failed: "+err.Error(), 0)
+				}
+				fmt.Println(errorStyle.Render("Request failed: " + err.Error()))
+				os.Exit(1)
+			}
+			if status == 404 {
+				if jsonMode {
+					dieJSON(fmt.Sprintf("Agent %q not found", args[0]), 404)
+				}
+				fmt.Println(errorStyle.Render(fmt.Sprintf("Agent %q not found", args[0])))
+				os.Exit(1)
+			}
+			if status == 409 {
+				var errResp ErrorResponse
+				json.Unmarshal(data, &errResp)
+				if jsonMode {
+					dieJSON(errResp.Error, 409)
+				}
+				fmt.Println(warnStyle.Render("⚠ " + errResp.Error))
+				os.Exit(1)
+			}
+			if status != 200 {
+				if jsonMode {
+					dieJSON(fmt.Sprintf("API error (%d): %s", status, string(data)), status)
+				}
+				fmt.Println(errorStyle.Render(fmt.Sprintf("API error (%d): %s", status, string(data))))
+				os.Exit(1)
+			}
+			if jsonMode {
+				printJSON(map[string]any{"name": args[0], "compacting": true})
+				return
+			}
+			fmt.Println(successStyle.Render(fmt.Sprintf("✔ Compacting conversation on %q", args[0])))
+		},
+	}
+	compactCmd.Flags().String("instructions", "", "Optional guidance for the compactor (e.g. \"preserve all code blocks\")")
+	root.AddCommand(compactCmd)
 
 	// ── config ───────────────────────────────────────────────────────────
 	configCmd := &cobra.Command{

--- a/komputer-operator/api/v1alpha1/komputeragent_types.go
+++ b/komputer-operator/api/v1alpha1/komputeragent_types.go
@@ -60,6 +60,10 @@ type AgentTaskStatus string
 const (
 	AgentTaskComplete   AgentTaskStatus = "Complete"
 	AgentTaskInProgress AgentTaskStatus = "InProgress"
+	// AgentTaskCompacting is a transient sub-state of InProgress while Claude Code
+	// is summarizing older conversation turns to free up context window space.
+	// Cleared back to InProgress once the next non-compaction event arrives.
+	AgentTaskCompacting AgentTaskStatus = "Compacting"
 	AgentTaskError      AgentTaskStatus = "Error"
 )
 

--- a/komputer-ui/src/app/agents/[name]/page.tsx
+++ b/komputer-ui/src/app/agents/[name]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
-import { Ban, Trash2, Zap, Moon, Save, Check, Plus, ChevronRight, Settings as SettingsIcon, MessageCircle, ArrowLeft, Users } from "lucide-react";
+import { Ban, Trash2, Zap, Moon, Save, Check, Plus, ChevronRight, Settings as SettingsIcon, MessageCircle, ArrowLeft, Users, Layers } from "lucide-react";
 import Link from "next/link";
 import { CreateSecretModal } from "@/components/secrets/create-secret-modal";
 import { Button } from "@/components/kit/button";
@@ -18,7 +18,7 @@ import { AgentChat } from "@/components/agents/agent-chat";
 import { SquadChatView } from "@/components/agents/squad-chat-view";
 import { useWebSocket } from "@/hooks/use-websocket";
 import { useDelayedLoading } from "@/hooks/use-delayed-loading";
-import { getAgent, deleteAgent, cancelAgent, createAgent, getAgentEvents, patchAgent, listMemories, listSkills, listSecrets, listConnectors, deleteSquad } from "@/lib/api";
+import { getAgent, deleteAgent, cancelAgent, compactAgent, createAgent, getAgentEvents, patchAgent, listMemories, listSkills, listSecrets, listConnectors, deleteSquad } from "@/lib/api";
 import { useSquads } from "@/hooks/use-squads";
 import { TeamUpDialog } from "@/components/agents/team-up-dialog";
 import { LeaveSquadButton } from "@/components/squads/leave-squad-button";
@@ -211,7 +211,8 @@ export default function AgentDetailPage() {
   // Poll only while status is transient (Pending, or Running with an active task)
   const needsPolling = agent != null && (
     agent.status === "Pending" ||
-    agent.taskStatus === "InProgress"
+    agent.taskStatus === "InProgress" ||
+    agent.taskStatus === "Compacting"
   );
   useEffect(() => {
     if (!needsPolling) return;
@@ -242,6 +243,45 @@ export default function AgentDetailPage() {
       // Will be reflected in next poll
     }
   };
+
+  const [compactBusy, setCompactBusy] = useState(false);
+  const [compactNote, setCompactNote] = useState<string | null>(null);
+  // Set to the ISO time of the request when the user clicks Compact. The chat
+  // shows an inline 'Compacting…' line until a compaction event with a timestamp
+  // >= this value lands (the agent emitted one). Auto-clears after 30s to avoid
+  // a stuck indicator if the agent never compacts (e.g. it stopped mid-request).
+  const [compactionRequestedAt, setCompactionRequestedAt] = useState<string | null>(null);
+  const handleCompact = async () => {
+    if (!agentName || compactBusy) return;
+    setCompactBusy(true);
+    setCompactNote(null);
+    try {
+      await compactAgent(agentName, { namespace: agentNs });
+      setCompactNote("Compacting…");
+      setCompactionRequestedAt(new Date().toISOString());
+      window.setTimeout(() => setCompactionRequestedAt(null), 30_000);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Compaction failed";
+      // Friendly message for the most common case (no active task)
+      setCompactNote(/409/.test(msg) || /no active task/i.test(msg) ? "No active task to compact" : msg);
+    } finally {
+      window.setTimeout(() => setCompactBusy(false), 2000);
+      window.setTimeout(() => setCompactNote(null), 4000);
+    }
+  };
+
+  // When a compaction event lands at or after the request timestamp, clear the
+  // pending indicator — the divider will now appear in its place.
+  // Hand off the indicator from the parent-prop (instant on click) to the
+  // CR-derived signal (taskStatus === "Compacting") only once the CR has caught
+  // up. That avoids a flicker between the two signals — the chat sees a
+  // continuous indicator until the worker flips taskStatus back to InProgress.
+  useEffect(() => {
+    if (!compactionRequestedAt) return;
+    if (agent?.taskStatus === "Compacting") {
+      setCompactionRequestedAt(null);
+    }
+  }, [agent?.taskStatus, compactionRequestedAt]);
 
   const handleDelete = async (opts?: { recreatePod?: boolean }) => {
     if (!agentName) return;
@@ -394,7 +434,7 @@ export default function AgentDetailPage() {
                   </Button>
                 ) : (
                   <>
-                    {agent.taskStatus === "InProgress" && (
+                    {(agent.taskStatus === "InProgress" || agent.taskStatus === "Compacting") && (
                       <Button variant="secondary" size="sm" onClick={handleCancel}>
                         <Ban className="size-3" data-icon="inline-start" />
                         Cancel
@@ -422,6 +462,17 @@ export default function AgentDetailPage() {
                     Team Up
                   </Button>
                 )}
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleCompact}
+                  disabled={compactBusy}
+                  title="Compact conversation history. Queues /compact as a follow-up message — runs as soon as the current turn finishes (or immediately if the agent is idle and responsive)."
+                  className="border-amber-500/40 bg-amber-500/10 text-amber-300 hover:bg-amber-500/15 hover:border-amber-500/55 hover:text-amber-200"
+                >
+                  <Layers className="size-3" data-icon="inline-start" />
+                  {compactNote ?? (compactBusy ? "Compacting…" : "Compact")}
+                </Button>
                 {agentSquad ? (
                   <SquadAwareDeleteButton
                     agentName={agent.name}
@@ -500,6 +551,7 @@ export default function AgentDetailPage() {
                   hasNewerEvents={hasNewerEvents}
                   loadingNewer={loadingNewer}
                   onLoadNewer={loadNewerEvents}
+                  compactionPending={compactionRequestedAt != null}
                 />
               );
               if (agentSquad && agentSquad.members.length > 1) {

--- a/komputer-ui/src/app/page.tsx
+++ b/komputer-ui/src/app/page.tsx
@@ -331,8 +331,8 @@ export default function DashboardPage() {
     Failed: squads.filter((s) => s.phase === "Failed").length,
   };
 
-  // Running tasks (agents with InProgress task)
-  const runningTasks = agents.filter((a) => a.taskStatus === "InProgress");
+  // Running tasks (agents with InProgress or Compacting task)
+  const runningTasks = agents.filter((a) => a.taskStatus === "InProgress" || a.taskStatus === "Compacting");
 
   // Recent agents — fill 2 rows at the widest breakpoint (6 cols × 2 = 12)
   const recentAgents = [...agents]

--- a/komputer-ui/src/components/agents/agent-cards.tsx
+++ b/komputer-ui/src/components/agents/agent-cards.tsx
@@ -49,7 +49,7 @@ export function AgentCards({ agents, onDelete, selected, onToggleSelect }: Agent
         {agents.map((agent, i) => {
           const cfg = statusConfig[agent.status] ?? defaultStatus;
           const StatusIcon = cfg.icon;
-          const isActive = agent.taskStatus === "InProgress";
+          const isActive = agent.taskStatus === "InProgress" || agent.taskStatus === "Compacting";
           const key = agentKey(agent);
           const isSelected = !!selected?.has(key);
           const squad = agentSquadMap.get(agent.name);

--- a/komputer-ui/src/components/agents/agent-chat.tsx
+++ b/komputer-ui/src/components/agents/agent-chat.tsx
@@ -48,6 +48,8 @@ type AgentChatProps = {
   hasNewerEvents?: boolean;
   loadingNewer?: boolean;
   onLoadNewer?: () => void;
+  /** Parent sets this true between Compact-button click and the arrival of a compaction event. */
+  compactionPending?: boolean;
 };
 
 // --- Message types derived from events ---
@@ -87,7 +89,16 @@ type ChatMessage =
     }
   | { kind: "error"; message: string; timestamp: string }
   | { kind: "cancelled"; timestamp: string }
-  | { kind: "compaction"; trigger?: "auto" | "manual"; timestamp: string };
+  | {
+      kind: "compaction";
+      trigger?: "auto" | "manual";
+      tokensBefore?: number;
+      tokensAfter?: number;
+      tokensFreed?: number;
+      costUSD?: string;
+      duration?: string;
+      timestamp: string;
+    };
 
 export function eventsToChatMessages(events: AgentEvent[]): ChatMessage[] {
   const messages: ChatMessage[] = [];
@@ -96,7 +107,10 @@ export function eventsToChatMessages(events: AgentEvent[]): ChatMessage[] {
       case "task_started": {
         const instructions =
           (event.payload.instructions ?? event.payload.message ?? "").trim();
-        if (instructions) {
+        // Don't render bare slash commands (e.g. "/compact") as user messages —
+        // they're internal control signals, not human input. The compaction
+        // divider (or other side-effect rendering) is the visible signal.
+        if (instructions && !instructions.startsWith("/")) {
           messages.push({
             kind: "user",
             text: instructions,
@@ -210,9 +224,11 @@ export function eventsToChatMessages(events: AgentEvent[]): ChatMessage[] {
         break;
       case "compaction": {
         const t = event.payload?.trigger;
+        const before = typeof event.payload?.tokens_before === "number" ? event.payload.tokens_before : undefined;
         messages.push({
           kind: "compaction",
           trigger: t === "manual" ? "manual" : t === "auto" ? "auto" : undefined,
+          tokensBefore: before,
           timestamp: event.timestamp,
         });
         break;
@@ -227,7 +243,53 @@ export function eventsToChatMessages(events: AgentEvent[]): ChatMessage[] {
         break;
     }
   }
-  return messages;
+
+  // Post-process: for each compaction message, look forward for a signal that
+  // tells us the post-compaction context size and compute tokensAfter / freed.
+  //   1. Next assistant `text` message that carries usage — the normal "next
+  //      turn after compaction" case (auto-compaction during a longer task).
+  //   2. Next `completed` message's contextTokens — the standalone /compact
+  //      path's task ends with task_completed and no text in between. In this
+  //      case the task's purpose WAS the compaction, so we also absorb the
+  //      cost/duration into the compaction divider and drop the standalone
+  //      "Task completed" divider that would otherwise read as a separate task.
+  // If neither has arrived yet, leave tokensAfter unset; the renderer suppresses
+  // the divider until it's filled in.
+  const indicesToDrop = new Set<number>();
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i];
+    if (m.kind !== "compaction" || m.tokensBefore == null) continue;
+    for (let j = i + 1; j < messages.length; j++) {
+      const n = messages[j];
+      if (n.kind === "compaction") break; // next compaction starts a new window
+      let after: number | undefined;
+      let absorbCompletion = false;
+      if (n.kind === "text" && n.usage) {
+        after =
+          (n.usage.input_tokens ?? 0) +
+          (n.usage.cache_read_input_tokens ?? 0) +
+          (n.usage.cache_creation_input_tokens ?? 0);
+      } else if (n.kind === "completed" && n.contextTokens != null) {
+        after = n.contextTokens;
+        // Standalone /compact task: the completed message describes the
+        // compaction work itself, not a separate user task. Merge.
+        absorbCompletion = true;
+      }
+      if (after != null) {
+        m.tokensAfter = after;
+        m.tokensFreed = Math.max(0, m.tokensBefore - after);
+        if (absorbCompletion && n.kind === "completed") {
+          m.costUSD = n.costUSD;
+          m.duration = n.duration;
+          indicesToDrop.add(j);
+        }
+        break;
+      }
+    }
+  }
+  return indicesToDrop.size > 0
+    ? messages.filter((_, idx) => !indicesToDrop.has(idx))
+    : messages;
 }
 
 function formatTimestamp(ts: string): string {
@@ -729,18 +791,78 @@ function CancelledDivider() {
   );
 }
 
-function CompactionDivider({ trigger }: { trigger?: "auto" | "manual" }) {
-  const label =
+function CompactionDivider({
+  trigger,
+  tokensBefore,
+  tokensAfter,
+  tokensFreed,
+  costUSD,
+  duration,
+}: {
+  trigger?: "auto" | "manual";
+  tokensBefore?: number;
+  tokensAfter?: number;
+  tokensFreed?: number;
+  costUSD?: string;
+  duration?: string;
+}) {
+  const action =
     trigger === "manual"
       ? "Context compacted manually"
       : trigger === "auto"
       ? "Context auto-compacted"
       : "Context compacted";
+
+  // Build the detail string. Show only the post-compaction picture, lead with the
+  // most user-meaningful number ("freed Nk"):
+  //   freed Nk tokens (Mk → Pk)
+  // During the gap between the compaction event and the next assistant message
+  // (when we know `before` but not `after` yet) we render the divider with no
+  // detail — the action label alone — and let it fill in when the after value
+  // arrives. This avoids the slightly confusing "from Nk tokens" intermediate
+  // state that doesn't tell the user what just happened.
+  let detail: string | null = null;
+  if (tokensBefore != null && tokensAfter != null) {
+    const before = formatTokenCount(tokensBefore);
+    const after = formatTokenCount(tokensAfter);
+    if (tokensFreed != null && tokensFreed > 0) {
+      detail = `freed ${formatTokenCount(tokensFreed)} tokens (${before} → ${after})`;
+    } else {
+      detail = `${before} → ${after}`;
+    }
+  }
+
+  const hasStats = costUSD || duration;
+
   return (
-    <div className="flex items-center gap-3 py-2" title="Older conversation turns were summarized to free up context space">
-      <div className="flex-1 border-t border-purple-400/20" />
-      <span className="text-xs font-medium text-purple-400">{label}</span>
-      <div className="flex-1 border-t border-purple-400/20" />
+    <div
+      className="py-2"
+      title="Older conversation turns were summarized to free up context space"
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex-1 border-t border-purple-400/20" />
+        <span className="text-xs font-medium text-purple-400 whitespace-nowrap">
+          {action}
+          {detail && (
+            <span className="ml-1.5 font-normal text-purple-300/80 tabular-nums">· {detail}</span>
+          )}
+        </span>
+        <div className="flex-1 border-t border-purple-400/20" />
+      </div>
+      {hasStats && (
+        <div className="mt-1.5 flex items-center justify-center gap-3">
+          {costUSD && (
+            <span className="rounded-full bg-[var(--color-surface-raised)] px-2.5 py-0.5 font-semibold [&>span]:text-[var(--color-text)]">
+              <CostBadge cost={costUSD} />
+            </span>
+          )}
+          {duration && (
+            <span className="text-xs text-[var(--color-text-secondary)]">
+              {duration}
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -817,8 +939,27 @@ export const MessageList = React.memo(function MessageList({ messages, agentName
         return <CompletedDivider key={key} costUSD={msg.costUSD} duration={msg.duration} turns={msg.turns} inputTokens={msg.inputTokens} outputTokens={msg.outputTokens} cacheReadTokens={msg.cacheReadTokens} cacheCreationTokens={msg.cacheCreationTokens} />;
       case "cancelled":
         return <CancelledDivider key={key} />;
-      case "compaction":
-        return <CompactionDivider key={key} trigger={msg.trigger} />;
+      case "compaction": {
+        // Don't render the divider during the in-flight phase (we know `before`
+        // but not `after` yet). The Compacting indicator at the bottom of the
+        // chat is the active signal during that gap — adding a divider above it
+        // would be a redundant placeholder. Exception: legacy/backfilled events
+        // with no token data at all still get the label-only divider.
+        const hasFullStats = msg.tokensAfter != null;
+        const hasNoStats = msg.tokensBefore == null && msg.tokensAfter == null;
+        if (!hasFullStats && !hasNoStats) return null;
+        return (
+          <CompactionDivider
+            key={key}
+            trigger={msg.trigger}
+            tokensBefore={msg.tokensBefore}
+            tokensAfter={msg.tokensAfter}
+            tokensFreed={msg.tokensFreed}
+            costUSD={msg.costUSD}
+            duration={msg.duration}
+          />
+        );
+      }
       case "error":
         return <ErrorBar key={key} message={msg.message} />;
     }
@@ -886,6 +1027,7 @@ export function AgentChat({
   hasNewerEvents,
   loadingNewer,
   onLoadNewer,
+  compactionPending,
 }: AgentChatProps) {
   const [input, setInputRaw] = useState(() => {
     if (typeof window === "undefined") return "";
@@ -950,7 +1092,7 @@ export function AgentChat({
       if (t === "task_completed" || t === "task_cancelled" || t === "error") return false;
       if (t === "task_started") return true;
     }
-    return taskStatus === "InProgress";
+    return taskStatus === "InProgress" || taskStatus === "Compacting";
   })();
 
   // Clear pendingText only when the task finishes — not when the server echoes the message
@@ -1286,7 +1428,10 @@ export function AgentChat({
             )}
             <MessageList messages={messages} agentName={agentName} agentNamespace={agentNamespace} highlightFrom={highlightTaskFrom} highlightTo={highlightTaskTo} />
             <AnimatePresence>
-            {showThinking && (
+            {/* Mutually exclusive: when a compaction is happening, suppress the
+                Thinking indicator. Both describe the same moment, just at different
+                specificity — Compacting is the more precise label. */}
+            {!(compactionPending || taskStatus === "Compacting") && showThinking && (
               <motion.div
                 className="flex items-center gap-2.5 py-1"
                 initial={{ opacity: 0, y: 8 }}
@@ -1315,6 +1460,35 @@ export function AgentChat({
                     · {formatThinkingDuration(thinkingElapsedMs)}
                   </span>
                 </span>
+              </motion.div>
+            )}
+            {(compactionPending || taskStatus === "Compacting") && (
+              <motion.div
+                key="compacting-indicator"
+                className="flex items-center gap-3 py-1.5"
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -8, transition: { duration: 0.2, ease: "easeIn" } }}
+                transition={{ duration: 0.2 }}
+              >
+                <div className="flex-1 border-t border-purple-400/15" />
+                <div className="flex items-center gap-1.5">
+                  {[0, 1, 2].map((i) => (
+                    <motion.span
+                      key={i}
+                      className="size-1.5 rounded-full bg-purple-400"
+                      animate={{ opacity: [0.3, 1, 0.3], scale: [0.8, 1.1, 0.8] }}
+                      transition={{
+                        duration: 1.2,
+                        repeat: Infinity,
+                        delay: i * 0.2,
+                        ease: "easeInOut",
+                      }}
+                    />
+                  ))}
+                  <span className="ml-1 text-xs font-medium text-purple-400">Compacting…</span>
+                </div>
+                <div className="flex-1 border-t border-purple-400/15" />
               </motion.div>
             )}
             </AnimatePresence>

--- a/komputer-ui/src/components/agents/sub-agent-panel.tsx
+++ b/komputer-ui/src/components/agents/sub-agent-panel.tsx
@@ -168,6 +168,7 @@ function SubAgentCard({ info, namespace, exists, agentPhase, memberStatus }: { i
     // Fall back to office member status
     if (memberStatus === "Complete") return "Succeeded";
     if (memberStatus === "InProgress") return "Running";
+    if (memberStatus === "Compacting") return "Running";
     if (memberStatus === "Error") return "Failed";
     return "Pending";
   }, [events, exists, agentPhase, memberStatus]);
@@ -367,7 +368,7 @@ export function SubAgentPanel({ agentName, events, namespace }: { agentName: str
     const isActive = (name: string) => {
       const phase = agentStatuses[name];
       const task = memberStatuses[name];
-      return phase === "Running" || phase === "Pending" || task === "InProgress";
+      return phase === "Running" || phase === "Pending" || task === "InProgress" || task === "Compacting";
     };
     const isDead = (name: string) => {
       const phase = agentStatuses[name];

--- a/komputer-ui/src/components/shared/status-badge.tsx
+++ b/komputer-ui/src/components/shared/status-badge.tsx
@@ -10,6 +10,7 @@ const statusColorMap: Record<string, { dot: string; text: string }> = {
   Running: { dot: "bg-[#34D399]", text: "text-[var(--color-text)]" },
   Active: { dot: "bg-[#34D399]", text: "text-[var(--color-text)]" },
   InProgress: { dot: "bg-[#34D399]", text: "text-[var(--color-text)]" },
+  Compacting: { dot: "bg-[#C084FC]", text: "text-[var(--color-text)]" },
   Sleeping: { dot: "bg-[#FBBF24]", text: "text-[var(--color-text)]" },
   Suspended: { dot: "bg-[#FBBF24]", text: "text-[var(--color-text)]" },
   Failed: { dot: "bg-[#F87171]", text: "text-[var(--color-text)]" },
@@ -24,7 +25,7 @@ const defaultColors = { dot: "bg-[var(--color-text-secondary)]", text: "text-[va
 
 export function StatusBadge({ status, size = "md" }: StatusBadgeProps) {
   const colors = statusColorMap[status] ?? defaultColors;
-  const shouldPulse = ["Running", "Active", "InProgress"].includes(status);
+  const shouldPulse = ["Running", "Active", "InProgress", "Compacting"].includes(status);
 
   return (
     <Badge

--- a/komputer-ui/src/lib/api.ts
+++ b/komputer-ui/src/lib/api.ts
@@ -81,6 +81,15 @@ export const deleteAgent = (name: string, ns?: string, opts?: { recreatePod?: bo
 export const cancelAgent = (name: string, ns?: string) =>
   request<void>(`/agents/${name}/cancel${ns ? `?namespace=${ns}` : ''}`, { method: 'POST' });
 
+export const compactAgent = (name: string, opts?: { instructions?: string; namespace?: string }) =>
+  request<{ status: string; name: string }>(
+    `/agents/${name}/compact${opts?.namespace ? `?namespace=${opts.namespace}` : ''}`,
+    {
+      method: 'POST',
+      body: opts?.instructions ? JSON.stringify({ instructions: opts.instructions }) : undefined,
+    }
+  );
+
 export const getAgentEvents = (name: string, limit = 50, ns?: string, before?: string, source?: 'session' | 'redis', around?: string, after?: string) =>
   request<AgentEvent[]>(`/agents/${name}/events?limit=${limit}${ns ? `&namespace=${ns}` : ''}${before ? `&before=${encodeURIComponent(before)}` : ''}${source ? `&source=${source}` : ''}${around ? `&around=${encodeURIComponent(around)}` : ''}${after ? `&after=${encodeURIComponent(after)}` : ''}`);
 

--- a/komputer-ui/src/lib/types.ts
+++ b/komputer-ui/src/lib/types.ts
@@ -10,7 +10,7 @@ export interface AgentResponse {
   namespace: string;
   model: string;
   status: AgentStatus;
-  taskStatus?: 'InProgress' | 'Complete' | 'Error';
+  taskStatus?: 'InProgress' | 'Compacting' | 'Complete' | 'Error';
   lastTaskMessage?: string;
   lifecycle?: '' | 'Sleep' | 'AutoDelete';
   lastTaskCostUSD?: string;


### PR DESCRIPTION
## Summary
- Manual compaction across UI, API, CLI, manager-tools, and external MCP. `Compact` button on the agent detail page (between the existing buttons and Delete) triggers `POST /api/v1/agents/{name}/compact`.
- Works whether the agent is **busy** (queues `/compact` as a follow-up on the live SDK session) or **idle** (spawns a fresh `/compact`-only task). Both paths fire the bundled Claude Code CLI's `PreCompact` hook with `trigger="manual"`.
- New transient `TaskStatus=Compacting` so the indicator state survives a page refresh — the persistent CR is the source of truth, not just transient UI state.
- The compaction event payload now carries `tokens_before`; the API seeds it from `CR.status.totalTokens` when the agent's in-session usage isn't known (idle path).
- Chat divider renders `Context compacted manually · freed Nk tokens (Mk → Pk)` with the cost pill below. When the task was just a standalone `/compact`, the "Task completed" divider is absorbed into the compaction divider instead of stacking.
- Mutually exclusive indicators: `Compacting…` takes precedence over `Thinking` so users see one signal at a time.
- `/compact` slash command no longer leaks as a user message bubble in the chat.

## Test plan
- [ ] Click Compact while agent is **idle** → `Compacting…` indicator appears instantly, persists across page refresh, divider lands with `freed Nk tokens (Mk → Pk)` and cost pill once complete.
- [ ] Click Compact while agent is **busy** with a task → `/compact` queues; same end-state UI.
- [ ] Click Compact when API can't reach the agent (e.g. pod missing) → friendly 409 message in the button label.
- [ ] `komputer agent compact <name>` from the CLI succeeds, returns 409 on idle pod-less agents, and includes `Compacting` row in `komputer agent list`.
- [ ] `compact_agent` MCP tool callable via the API's `/mcp` endpoint and via a manager agent's tool list.
- [ ] Refresh during an in-flight compaction shows the persistent indicator AND no duplicate `Thinking` indicator.
- [ ] Backfilled (replayed) compaction events with no token data still show the unadorned divider.
- [ ] Auto-compaction (the v0.16-era behavior) still works: the divider shows with `freed` info derived from the next assistant `text` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
