### PR TITLE
feat(schedules): edit any spec field across UI/API/CLI/SDK

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,6 +9,11 @@ description: Install komputer.ai on any Kubernetes cluster with Helm in under 5 
 - `kubectl` configured
 - `helm` 3.x installed
 - An [Anthropic API key](https://console.anthropic.com/) — or AWS Bedrock access (install with `--set bedrock.enabled=true --set bedrock.region=<region>` instead; auth is via IRSA on EKS or AWS credentials)
+- [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster — required for the operator's admission webhook (which validates `KomputerSquad` resources). The chart provisions a self-signed `Issuer` + `Certificate` automatically; cert-manager just needs to be present:
+  ```bash
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.2/cert-manager.yaml
+  ```
+  > If you genuinely cannot install cert-manager, disable the webhook with `--set webhooks.enabled=false` — but you lose squad-membership validation. See the [Helm chart README](https://github.com/komputer-ai/komputer-ai/tree/main/helm/komputer-ai#squad-admission-webhook) for the trade-off.
 
 ## 1. Create the Anthropic API key secret
 

--- a/komputer-api/docs/docs.go
+++ b/komputer-api/docs/docs.go
@@ -1457,6 +1457,69 @@ const docTemplate = `{
                 }
             }
         },
+        "/schedules/{name}/trigger": {
+            "post": {
+                "description": "Fires the schedule immediately, independent of its cron cadence. Returns 409 if a run is already in progress.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "Trigger schedule now",
+                "operationId": "triggerSchedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Schedule name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Triggered",
+                        "schema": {
+                            "$ref": "#/definitions/main.TriggerScheduleResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Schedule not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "A run is already in progress",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/secrets": {
             "get": {
                 "description": "Returns all secrets with key names (not values) and attached agent counts in the specified namespace.",
@@ -2505,6 +2568,9 @@ const docTemplate = `{
         "main.AgentResponse": {
             "type": "object",
             "properties": {
+                "completionTime": {
+                    "type": "string"
+                },
                 "connectors": {
                     "description": "KomputerConnector names attached to this agent",
                     "type": "array",
@@ -2525,6 +2591,12 @@ const docTemplate = `{
                 "instructions": {
                     "description": "User task (spec.instructions)",
                     "type": "string"
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "lastTaskCostUSD": {
                     "type": "string"
@@ -2636,6 +2708,9 @@ const docTemplate = `{
                 "displayName": {
                     "type": "string"
                 },
+                "headerName": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -2673,6 +2748,13 @@ const docTemplate = `{
                 },
                 "instructions": {
                     "type": "string"
+                },
+                "labels": {
+                    "description": "Labels are user-defined key=value labels passed through to the agent CR.\nReserved-prefix keys (komputer.ai/*) are rejected except for\n\"komputer.ai/personal-agent\" which is allow-listed.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "lifecycle": {
                     "description": "\"\", \"Sleep\", or \"AutoDelete\"",
@@ -2751,10 +2833,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "authType": {
-                    "description": "\"token\" or \"oauth\"",
+                    "description": "\"token\", \"oauth\", or \"header\"",
                     "type": "string"
                 },
                 "displayName": {
+                    "type": "string"
+                },
+                "headerName": {
+                    "description": "custom header name when authType is \"header\"",
                     "type": "string"
                 },
                 "name": {
@@ -3042,6 +3128,12 @@ const docTemplate = `{
                 "instructions": {
                     "type": "string"
                 },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "lifecycle": {
                     "type": "string"
                 },
@@ -3102,7 +3194,28 @@ const docTemplate = `{
         "main.PatchScheduleRequest": {
             "type": "object",
             "properties": {
+                "agent": {
+                    "$ref": "#/definitions/main.CreateScheduleAgentSpec"
+                },
+                "agentName": {
+                    "type": "string"
+                },
+                "autoDelete": {
+                    "type": "boolean"
+                },
+                "instructions": {
+                    "type": "string"
+                },
+                "keepAgents": {
+                    "type": "boolean"
+                },
                 "schedule": {
+                    "type": "string"
+                },
+                "suspended": {
+                    "type": "boolean"
+                },
+                "timezone": {
                     "type": "string"
                 }
             }
@@ -3146,6 +3259,9 @@ const docTemplate = `{
         "main.ScheduleResponse": {
             "type": "object",
             "properties": {
+                "agent": {
+                    "$ref": "#/definitions/main.CreateScheduleAgentSpec"
+                },
                 "agentName": {
                     "type": "string"
                 },
@@ -3157,6 +3273,9 @@ const docTemplate = `{
                 },
                 "failedRuns": {
                     "type": "integer"
+                },
+                "instructions": {
+                    "type": "string"
                 },
                 "keepAgents": {
                     "type": "boolean"
@@ -3193,6 +3312,9 @@ const docTemplate = `{
                 },
                 "successfulRuns": {
                     "type": "integer"
+                },
+                "suspended": {
+                    "type": "boolean"
                 },
                 "timezone": {
                     "type": "string"
@@ -3342,6 +3464,20 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "podName": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.TriggerScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "agentName": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
                     "type": "string"
                 }
             }
@@ -7509,6 +7645,13 @@ const docTemplate = `{
                 "internalSystemPrompt": {
                     "description": "InternalSystemPrompt is the built-in system prompt set by the API (role prompt + memories).\n+optional",
                     "type": "string"
+                },
+                "labels": {
+                    "description": "Labels are user-defined key=value labels attached to this agent and\npropagated to all child resources (Pod, PVC, ConfigMap, Service).\nKeys starting with \"komputer.ai/\" are reserved for system labels and\nshould not be set directly through the API.\n+optional",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "lifecycle": {
                     "description": "Lifecycle controls what happens after task completion.\nEmpty (default) keeps the pod running, \"Sleep\" deletes the pod but keeps the PVC,\n\"AutoDelete\" deletes the entire agent after task completion.\n+kubebuilder:validation:Enum=\"\";Sleep;AutoDelete\n+optional",

--- a/komputer-api/docs/swagger.json
+++ b/komputer-api/docs/swagger.json
@@ -1451,6 +1451,69 @@
                 }
             }
         },
+        "/schedules/{name}/trigger": {
+            "post": {
+                "description": "Fires the schedule immediately, independent of its cron cadence. Returns 409 if a run is already in progress.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "schedules"
+                ],
+                "summary": "Trigger schedule now",
+                "operationId": "triggerSchedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Schedule name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Kubernetes namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Triggered",
+                        "schema": {
+                            "$ref": "#/definitions/main.TriggerScheduleResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Schedule not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "A run is already in progress",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/secrets": {
             "get": {
                 "description": "Returns all secrets with key names (not values) and attached agent counts in the specified namespace.",
@@ -2499,6 +2562,9 @@
         "main.AgentResponse": {
             "type": "object",
             "properties": {
+                "completionTime": {
+                    "type": "string"
+                },
                 "connectors": {
                     "description": "KomputerConnector names attached to this agent",
                     "type": "array",
@@ -2519,6 +2585,12 @@
                 "instructions": {
                     "description": "User task (spec.instructions)",
                     "type": "string"
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "lastTaskCostUSD": {
                     "type": "string"
@@ -2630,6 +2702,9 @@
                 "displayName": {
                     "type": "string"
                 },
+                "headerName": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -2667,6 +2742,13 @@
                 },
                 "instructions": {
                     "type": "string"
+                },
+                "labels": {
+                    "description": "Labels are user-defined key=value labels passed through to the agent CR.\nReserved-prefix keys (komputer.ai/*) are rejected except for\n\"komputer.ai/personal-agent\" which is allow-listed.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "lifecycle": {
                     "description": "\"\", \"Sleep\", or \"AutoDelete\"",
@@ -2745,10 +2827,14 @@
                     "type": "string"
                 },
                 "authType": {
-                    "description": "\"token\" or \"oauth\"",
+                    "description": "\"token\", \"oauth\", or \"header\"",
                     "type": "string"
                 },
                 "displayName": {
+                    "type": "string"
+                },
+                "headerName": {
+                    "description": "custom header name when authType is \"header\"",
                     "type": "string"
                 },
                 "name": {
@@ -3036,6 +3122,12 @@
                 "instructions": {
                     "type": "string"
                 },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "lifecycle": {
                     "type": "string"
                 },
@@ -3096,7 +3188,28 @@
         "main.PatchScheduleRequest": {
             "type": "object",
             "properties": {
+                "agent": {
+                    "$ref": "#/definitions/main.CreateScheduleAgentSpec"
+                },
+                "agentName": {
+                    "type": "string"
+                },
+                "autoDelete": {
+                    "type": "boolean"
+                },
+                "instructions": {
+                    "type": "string"
+                },
+                "keepAgents": {
+                    "type": "boolean"
+                },
                 "schedule": {
+                    "type": "string"
+                },
+                "suspended": {
+                    "type": "boolean"
+                },
+                "timezone": {
                     "type": "string"
                 }
             }
@@ -3140,6 +3253,9 @@
         "main.ScheduleResponse": {
             "type": "object",
             "properties": {
+                "agent": {
+                    "$ref": "#/definitions/main.CreateScheduleAgentSpec"
+                },
                 "agentName": {
                     "type": "string"
                 },
@@ -3151,6 +3267,9 @@
                 },
                 "failedRuns": {
                     "type": "integer"
+                },
+                "instructions": {
+                    "type": "string"
                 },
                 "keepAgents": {
                     "type": "boolean"
@@ -3187,6 +3306,9 @@
                 },
                 "successfulRuns": {
                     "type": "integer"
+                },
+                "suspended": {
+                    "type": "boolean"
                 },
                 "timezone": {
                     "type": "string"
@@ -3336,6 +3458,20 @@
                     "type": "string"
                 },
                 "podName": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.TriggerScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "agentName": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
                     "type": "string"
                 }
             }
@@ -7503,6 +7639,13 @@
                 "internalSystemPrompt": {
                     "description": "InternalSystemPrompt is the built-in system prompt set by the API (role prompt + memories).\n+optional",
                     "type": "string"
+                },
+                "labels": {
+                    "description": "Labels are user-defined key=value labels attached to this agent and\npropagated to all child resources (Pod, PVC, ConfigMap, Service).\nKeys starting with \"komputer.ai/\" are reserved for system labels and\nshould not be set directly through the API.\n+optional",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "lifecycle": {
                     "description": "Lifecycle controls what happens after task completion.\nEmpty (default) keeps the pod running, \"Sleep\" deletes the pod but keeps the PVC,\n\"AutoDelete\" deletes the entire agent after task completion.\n+kubebuilder:validation:Enum=\"\";Sleep;AutoDelete\n+optional",

--- a/komputer-api/docs/swagger.yaml
+++ b/komputer-api/docs/swagger.yaml
@@ -60,6 +60,8 @@ definitions:
     type: object
   main.AgentResponse:
     properties:
+      completionTime:
+        type: string
       connectors:
         description: KomputerConnector names attached to this agent
         items:
@@ -78,6 +80,10 @@ definitions:
       instructions:
         description: User task (spec.instructions)
         type: string
+      labels:
+        additionalProperties:
+          type: string
+        type: object
       lastTaskCostUSD:
         type: string
       lastTaskMessage:
@@ -153,6 +159,8 @@ definitions:
         type: string
       displayName:
         type: string
+      headerName:
+        type: string
       name:
         type: string
       namespace:
@@ -176,6 +184,14 @@ definitions:
         type: array
       instructions:
         type: string
+      labels:
+        additionalProperties:
+          type: string
+        description: |-
+          Labels are user-defined key=value labels passed through to the agent CR.
+          Reserved-prefix keys (komputer.ai/*) are rejected except for
+          "komputer.ai/personal-agent" which is allow-listed.
+        type: object
       lifecycle:
         description: '"", "Sleep", or "AutoDelete"'
         type: string
@@ -230,9 +246,12 @@ definitions:
       authSecretName:
         type: string
       authType:
-        description: '"token" or "oauth"'
+        description: '"token", "oauth", or "header"'
         type: string
       displayName:
+        type: string
+      headerName:
+        description: custom header name when authType is "header"
         type: string
       name:
         type: string
@@ -428,6 +447,10 @@ definitions:
         type: array
       instructions:
         type: string
+      labels:
+        additionalProperties:
+          type: string
+        type: object
       lifecycle:
         type: string
       memories:
@@ -469,7 +492,21 @@ definitions:
     type: object
   main.PatchScheduleRequest:
     properties:
+      agent:
+        $ref: '#/definitions/main.CreateScheduleAgentSpec'
+      agentName:
+        type: string
+      autoDelete:
+        type: boolean
+      instructions:
+        type: string
+      keepAgents:
+        type: boolean
       schedule:
+        type: string
+      suspended:
+        type: boolean
+      timezone:
         type: string
     type: object
   main.PatchSkillRequest:
@@ -497,6 +534,8 @@ definitions:
     type: object
   main.ScheduleResponse:
     properties:
+      agent:
+        $ref: '#/definitions/main.CreateScheduleAgentSpec'
       agentName:
         type: string
       autoDelete:
@@ -505,6 +544,8 @@ definitions:
         type: string
       failedRuns:
         type: integer
+      instructions:
+        type: string
       keepAgents:
         type: boolean
       lastRunCostUSD:
@@ -529,6 +570,8 @@ definitions:
         type: string
       successfulRuns:
         type: integer
+      suspended:
+        type: boolean
       timezone:
         type: string
       totalCostUSD:
@@ -626,6 +669,15 @@ definitions:
       phase:
         type: string
       podName:
+        type: string
+    type: object
+  main.TriggerScheduleResponse:
+    properties:
+      agentName:
+        type: string
+      name:
+        type: string
+      status:
         type: string
     type: object
   main.UpdateSecretRequest:
@@ -5957,6 +6009,16 @@ definitions:
           InternalSystemPrompt is the built-in system prompt set by the API (role prompt + memories).
           +optional
         type: string
+      labels:
+        additionalProperties:
+          type: string
+        description: |-
+          Labels are user-defined key=value labels attached to this agent and
+          propagated to all child resources (Pod, PVC, ConfigMap, Service).
+          Keys starting with "komputer.ai/" are reserved for system labels and
+          should not be set directly through the API.
+          +optional
+        type: object
       lifecycle:
         allOf:
         - $ref: '#/definitions/v1alpha1.AgentLifecycle'
@@ -7074,6 +7136,49 @@ paths:
               type: string
             type: object
       summary: Patch schedule
+      tags:
+      - schedules
+  /schedules/{name}/trigger:
+    post:
+      description: Fires the schedule immediately, independent of its cron cadence.
+        Returns 409 if a run is already in progress.
+      operationId: triggerSchedule
+      parameters:
+      - description: Schedule name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Kubernetes namespace
+        in: query
+        name: namespace
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Triggered
+          schema:
+            $ref: '#/definitions/main.TriggerScheduleResponse'
+        "404":
+          description: Schedule not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: A run is already in progress
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Trigger schedule now
       tags:
       - schedules
   /secrets:

--- a/komputer-api/handler_schedules.go
+++ b/komputer-api/handler_schedules.go
@@ -34,26 +34,28 @@ type CreateScheduleAgentSpec struct {
 }
 
 type ScheduleResponse struct {
-	Name           string `json:"name"`
-	Namespace      string `json:"namespace"`
-	Schedule       string `json:"schedule"`
-	Instructions   string `json:"instructions"`
-	Timezone       string `json:"timezone,omitempty"`
-	AutoDelete     bool   `json:"autoDelete,omitempty"`
-	KeepAgents     bool   `json:"keepAgents,omitempty"`
-	Phase          string `json:"phase"`
-	AgentName      string `json:"agentName,omitempty"`
-	NextRunTime    string `json:"nextRunTime,omitempty"`
-	LastRunTime    string `json:"lastRunTime,omitempty"`
-	RunCount       int    `json:"runCount,omitempty"`
-	SuccessfulRuns int    `json:"successfulRuns,omitempty"`
-	FailedRuns     int    `json:"failedRuns,omitempty"`
-	TotalCostUSD   string `json:"totalCostUSD,omitempty"`
-	LastRunCostUSD string `json:"lastRunCostUSD,omitempty"`
-	TotalTokens    int64  `json:"totalTokens,omitempty"`
-	LastRunTokens  int64  `json:"lastRunTokens,omitempty"`
-	LastRunStatus  string `json:"lastRunStatus,omitempty"`
-	CreatedAt      string `json:"createdAt"`
+	Name           string                   `json:"name"`
+	Namespace      string                   `json:"namespace"`
+	Schedule       string                   `json:"schedule"`
+	Instructions   string                   `json:"instructions"`
+	Timezone       string                   `json:"timezone,omitempty"`
+	AutoDelete     bool                     `json:"autoDelete,omitempty"`
+	KeepAgents     bool                     `json:"keepAgents,omitempty"`
+	Suspended      bool                     `json:"suspended,omitempty"`
+	Agent          *CreateScheduleAgentSpec `json:"agent,omitempty"`
+	Phase          string                   `json:"phase"`
+	AgentName      string                   `json:"agentName,omitempty"`
+	NextRunTime    string                   `json:"nextRunTime,omitempty"`
+	LastRunTime    string                   `json:"lastRunTime,omitempty"`
+	RunCount       int                      `json:"runCount,omitempty"`
+	SuccessfulRuns int                      `json:"successfulRuns,omitempty"`
+	FailedRuns     int                      `json:"failedRuns,omitempty"`
+	TotalCostUSD   string                   `json:"totalCostUSD,omitempty"`
+	LastRunCostUSD string                   `json:"lastRunCostUSD,omitempty"`
+	TotalTokens    int64                    `json:"totalTokens,omitempty"`
+	LastRunTokens  int64                    `json:"lastRunTokens,omitempty"`
+	LastRunStatus  string                   `json:"lastRunStatus,omitempty"`
+	CreatedAt      string                   `json:"createdAt"`
 }
 
 type ScheduleListResponse struct {
@@ -61,8 +63,14 @@ type ScheduleListResponse struct {
 }
 
 type PatchScheduleRequest struct {
-	Schedule     *string `json:"schedule,omitempty"`
-	Instructions *string `json:"instructions,omitempty"`
+	Schedule     *string                  `json:"schedule,omitempty"`
+	Instructions *string                  `json:"instructions,omitempty"`
+	Timezone     *string                  `json:"timezone,omitempty"`
+	AutoDelete   *bool                    `json:"autoDelete,omitempty"`
+	KeepAgents   *bool                    `json:"keepAgents,omitempty"`
+	Suspended    *bool                    `json:"suspended,omitempty"`
+	AgentName    *string                  `json:"agentName,omitempty"`
+	Agent        *CreateScheduleAgentSpec `json:"agent,omitempty"`
 }
 
 type TriggerScheduleResponse struct {
@@ -81,6 +89,7 @@ func scheduleToResponse(s komputerv1alpha1.KomputerSchedule) ScheduleResponse {
 		Timezone:       s.Spec.Timezone,
 		AutoDelete:     s.Spec.AutoDelete,
 		KeepAgents:     s.Spec.KeepAgents,
+		Suspended:      s.Spec.Suspended,
 		Phase:          string(s.Status.Phase),
 		AgentName:      s.Status.AgentName,
 		RunCount:       s.Status.RunCount,
@@ -102,6 +111,15 @@ func scheduleToResponse(s komputerv1alpha1.KomputerSchedule) ScheduleResponse {
 	// Use spec agentName if status doesn't have one yet.
 	if resp.AgentName == "" {
 		resp.AgentName = s.Spec.AgentName
+	}
+	if s.Spec.Agent != nil {
+		resp.Agent = &CreateScheduleAgentSpec{
+			Model:       s.Spec.Agent.Model,
+			Lifecycle:   string(s.Spec.Agent.Lifecycle),
+			Role:        s.Spec.Agent.Role,
+			TemplateRef: s.Spec.Agent.TemplateRef,
+			SecretRefs:  s.Spec.Agent.Secrets,
+		}
 	}
 	return resp
 }
@@ -380,11 +398,13 @@ func patchSchedule(k8s *K8sClient) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
 			return
 		}
-		if req.Schedule == nil && req.Instructions == nil {
+		if req.Schedule == nil && req.Instructions == nil && req.Timezone == nil &&
+			req.AutoDelete == nil && req.KeepAgents == nil && req.Suspended == nil &&
+			req.AgentName == nil && req.Agent == nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no fields to update"})
 			return
 		}
-		if err := k8s.PatchScheduleSpec(c.Request.Context(), ns, name, req.Schedule, req.Instructions); err != nil {
+		if err := k8s.PatchScheduleSpec(c.Request.Context(), ns, name, req); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to patch schedule: " + err.Error()})
 			return
 		}

--- a/komputer-api/k8s.go
+++ b/komputer-api/k8s.go
@@ -894,12 +894,13 @@ func (k *K8sClient) GetSchedule(ctx context.Context, ns, name string) (*komputer
 }
 
 func (k *K8sClient) PatchScheduleCron(ctx context.Context, ns, name, cron string) error {
-	return k.PatchScheduleSpec(ctx, ns, name, &cron, nil)
+	return k.PatchScheduleSpec(ctx, ns, name, PatchScheduleRequest{Schedule: &cron})
 }
 
-// PatchScheduleSpec patches mutable spec fields (cron expression, instructions) on a schedule.
-// nil pointers are skipped.
-func (k *K8sClient) PatchScheduleSpec(ctx context.Context, ns, name string, cron, instructions *string) error {
+// PatchScheduleSpec patches mutable spec fields on a schedule. nil pointers are skipped.
+// AgentName and Agent are mutually exclusive: setting AgentName clears Agent and vice versa,
+// matching the create-time validation in KomputerScheduleSpec.
+func (k *K8sClient) PatchScheduleSpec(ctx context.Context, ns, name string, req PatchScheduleRequest) error {
 	schedule := &komputerv1alpha1.KomputerSchedule{}
 	key := types.NamespacedName{Name: name, Namespace: ns}
 	if err := k.client.Get(ctx, key, schedule); err != nil {
@@ -907,12 +908,48 @@ func (k *K8sClient) PatchScheduleSpec(ctx context.Context, ns, name string, cron
 	}
 	original := schedule.DeepCopy()
 	changed := false
-	if cron != nil && schedule.Spec.Schedule != *cron {
-		schedule.Spec.Schedule = *cron
+	if req.Schedule != nil && schedule.Spec.Schedule != *req.Schedule {
+		schedule.Spec.Schedule = *req.Schedule
 		changed = true
 	}
-	if instructions != nil && schedule.Spec.Instructions != *instructions {
-		schedule.Spec.Instructions = *instructions
+	if req.Instructions != nil && schedule.Spec.Instructions != *req.Instructions {
+		schedule.Spec.Instructions = *req.Instructions
+		changed = true
+	}
+	if req.Timezone != nil && schedule.Spec.Timezone != *req.Timezone {
+		schedule.Spec.Timezone = *req.Timezone
+		changed = true
+	}
+	if req.AutoDelete != nil && schedule.Spec.AutoDelete != *req.AutoDelete {
+		schedule.Spec.AutoDelete = *req.AutoDelete
+		changed = true
+	}
+	if req.KeepAgents != nil && schedule.Spec.KeepAgents != *req.KeepAgents {
+		schedule.Spec.KeepAgents = *req.KeepAgents
+		changed = true
+	}
+	if req.Suspended != nil && schedule.Spec.Suspended != *req.Suspended {
+		schedule.Spec.Suspended = *req.Suspended
+		changed = true
+	}
+	if req.AgentName != nil && schedule.Spec.AgentName != *req.AgentName {
+		schedule.Spec.AgentName = *req.AgentName
+		if *req.AgentName != "" {
+			// Targeting an existing agent — drop the inline template.
+			schedule.Spec.Agent = nil
+		}
+		changed = true
+	}
+	if req.Agent != nil {
+		schedule.Spec.Agent = &komputerv1alpha1.ScheduleAgentSpec{
+			Model:       req.Agent.Model,
+			Lifecycle:   komputerv1alpha1.AgentLifecycle(req.Agent.Lifecycle),
+			Role:        req.Agent.Role,
+			TemplateRef: req.Agent.TemplateRef,
+			Secrets:     req.Agent.SecretRefs,
+		}
+		// Inline template replaces any AgentName reference.
+		schedule.Spec.AgentName = ""
 		changed = true
 	}
 	if !changed {

--- a/komputer-cli/cmd_schedules.go
+++ b/komputer-cli/cmd_schedules.go
@@ -437,29 +437,74 @@ func registerScheduleCommands(root *cobra.Command) {
 
 	// ── schedule update ────────────────────────────────────────────────
 	scheduleUpdateCmd := &cobra.Command{
-		Use:   "update <name>",
-		Short: "Update a schedule's cron expression or instructions",
-		Args:  cobra.ExactArgs(1),
+		Use:     "update <name>",
+		Aliases: []string{"edit", "patch"},
+		Short:   "Update any editable field on a schedule",
+		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			jsonMode, _ := cmd.Flags().GetBool("json")
 			ep := resolveEndpoint(cmd)
 			scheduleName := args[0]
-			cron, _ := cmd.Flags().GetString("cron")
-			instructions, _ := cmd.Flags().GetString("instructions")
-			if cron == "" && instructions == "" {
-				if jsonMode {
-					dieJSON("must pass --cron and/or --instructions", 400)
-				}
-				fmt.Println(errorStyle.Render("must pass --cron and/or --instructions"))
-				os.Exit(1)
-			}
+
 			body := map[string]interface{}{}
-			if cron != "" {
+			if cmd.Flags().Changed("cron") {
+				cron, _ := cmd.Flags().GetString("cron")
 				body["schedule"] = cron
 			}
-			if instructions != "" {
+			if cmd.Flags().Changed("instructions") {
+				instructions, _ := cmd.Flags().GetString("instructions")
 				body["instructions"] = instructions
 			}
+			if cmd.Flags().Changed("timezone") {
+				tz, _ := cmd.Flags().GetString("timezone")
+				body["timezone"] = tz
+			}
+			if cmd.Flags().Changed("auto-delete") {
+				v, _ := cmd.Flags().GetBool("auto-delete")
+				body["autoDelete"] = v
+			}
+			if cmd.Flags().Changed("keep-agents") {
+				v, _ := cmd.Flags().GetBool("keep-agents")
+				body["keepAgents"] = v
+			}
+			if cmd.Flags().Changed("suspended") {
+				v, _ := cmd.Flags().GetBool("suspended")
+				body["suspended"] = v
+			}
+			if cmd.Flags().Changed("agent") {
+				agent, _ := cmd.Flags().GetString("agent")
+				body["agentName"] = agent
+			}
+			// Agent template fields — if any is set, build the inline template.
+			agentSpec := map[string]interface{}{}
+			for _, f := range []struct{ flag, key string }{
+				{"model", "model"},
+				{"lifecycle", "lifecycle"},
+				{"role", "role"},
+				{"template-ref", "templateRef"},
+			} {
+				if cmd.Flags().Changed(f.flag) {
+					v, _ := cmd.Flags().GetString(f.flag)
+					agentSpec[f.key] = v
+				}
+			}
+			if cmd.Flags().Changed("secret") {
+				secrets, _ := cmd.Flags().GetStringSlice("secret")
+				agentSpec["secretRefs"] = secrets
+			}
+			if len(agentSpec) > 0 {
+				body["agent"] = agentSpec
+			}
+
+			if len(body) == 0 {
+				msg := "no fields to update — pass at least one of --cron, --instructions, --timezone, --auto-delete, --keep-agents, --suspended, --agent, --model, --lifecycle, --role, --template-ref, --secret"
+				if jsonMode {
+					dieJSON(msg, 400)
+				}
+				fmt.Println(errorStyle.Render(msg))
+				os.Exit(1)
+			}
+
 			data, status, err := apiRequest("PATCH", fmt.Sprintf("%s/api/v1/schedules/%s%s", ep, url.PathEscape(scheduleName), nsQuery(cmd)), body)
 			if err != nil {
 				if jsonMode {
@@ -486,6 +531,16 @@ func registerScheduleCommands(root *cobra.Command) {
 	}
 	scheduleUpdateCmd.Flags().String("cron", "", "New cron expression")
 	scheduleUpdateCmd.Flags().String("instructions", "", "New instructions for the agent")
+	scheduleUpdateCmd.Flags().String("timezone", "", "New IANA timezone")
+	scheduleUpdateCmd.Flags().Bool("auto-delete", false, "Toggle auto-delete after first successful run")
+	scheduleUpdateCmd.Flags().Bool("keep-agents", false, "Toggle keep-agents on auto-delete")
+	scheduleUpdateCmd.Flags().Bool("suspended", false, "Toggle suspended state (paused without deletion)")
+	scheduleUpdateCmd.Flags().String("agent", "", "Target an existing agent by name (clears inline template)")
+	scheduleUpdateCmd.Flags().String("model", "", "Agent template: Claude model")
+	scheduleUpdateCmd.Flags().String("lifecycle", "", "Agent template: lifecycle (Sleep, AutoDelete, or empty)")
+	scheduleUpdateCmd.Flags().String("role", "", "Agent template: role")
+	scheduleUpdateCmd.Flags().String("template-ref", "", "Agent template: KomputerAgentTemplate ref")
+	scheduleUpdateCmd.Flags().StringSlice("secret", nil, "Agent template: secret refs (repeatable)")
 	scheduleCmd.AddCommand(scheduleUpdateCmd)
 
 	root.AddCommand(scheduleCmd)

--- a/komputer-cli/types.go
+++ b/komputer-cli/types.go
@@ -58,25 +58,35 @@ type OfficeListResponse struct {
 	Offices []OfficeResponse `json:"offices"`
 }
 
+type ScheduleAgentSpec struct {
+	Model       string   `json:"model,omitempty"`
+	Lifecycle   string   `json:"lifecycle,omitempty"`
+	Role        string   `json:"role,omitempty"`
+	TemplateRef string   `json:"templateRef,omitempty"`
+	SecretRefs  []string `json:"secretRefs,omitempty"`
+}
+
 type ScheduleResponse struct {
-	Name           string `json:"name"`
-	Namespace      string `json:"namespace"`
-	Schedule       string `json:"schedule"`
-	Instructions   string `json:"instructions"`
-	Timezone       string `json:"timezone"`
-	AutoDelete     bool   `json:"autoDelete"`
-	KeepAgents     bool   `json:"keepAgents"`
-	Phase          string `json:"phase"`
-	AgentName      string `json:"agentName"`
-	NextRunTime    string `json:"nextRunTime"`
-	LastRunTime    string `json:"lastRunTime"`
-	RunCount       int    `json:"runCount"`
-	SuccessfulRuns int    `json:"successfulRuns"`
-	FailedRuns     int    `json:"failedRuns"`
-	TotalCostUSD   string `json:"totalCostUSD"`
-	LastRunCostUSD string `json:"lastRunCostUSD"`
-	LastRunStatus  string `json:"lastRunStatus"`
-	CreatedAt      string `json:"createdAt"`
+	Name           string             `json:"name"`
+	Namespace      string             `json:"namespace"`
+	Schedule       string             `json:"schedule"`
+	Instructions   string             `json:"instructions"`
+	Timezone       string             `json:"timezone"`
+	AutoDelete     bool               `json:"autoDelete"`
+	KeepAgents     bool               `json:"keepAgents"`
+	Suspended      bool               `json:"suspended"`
+	Agent          *ScheduleAgentSpec `json:"agent,omitempty"`
+	Phase          string             `json:"phase"`
+	AgentName      string             `json:"agentName"`
+	NextRunTime    string             `json:"nextRunTime"`
+	LastRunTime    string             `json:"lastRunTime"`
+	RunCount       int                `json:"runCount"`
+	SuccessfulRuns int                `json:"successfulRuns"`
+	FailedRuns     int                `json:"failedRuns"`
+	TotalCostUSD   string             `json:"totalCostUSD"`
+	LastRunCostUSD string             `json:"lastRunCostUSD"`
+	LastRunStatus  string             `json:"lastRunStatus"`
+	CreatedAt      string             `json:"createdAt"`
 }
 
 type ScheduleListResponse struct {

--- a/komputer-sdk/go/client.go
+++ b/komputer-sdk/go/client.go
@@ -386,16 +386,43 @@ func (c *Client) GetSchedule(ctx context.Context, name string) (*komputer.Schedu
 }
 
 type PatchScheduleOpts struct {
-	Schedule *string
+	Schedule     *string
+	Instructions *string
+	Timezone     *string
+	AutoDelete   *bool
+	KeepAgents   *bool
+	Suspended    *bool
+	AgentName    *string
+	Agent        *komputer.CreateScheduleAgentSpec
 }
 
 func (c *Client) PatchSchedule(ctx context.Context, name string, opts ...PatchScheduleOpts) (*komputer.ScheduleResponse, *http.Response, error) {
-	req := komputer.PatchScheduleRequest{
-	}
+	req := komputer.PatchScheduleRequest{}
 	if len(opts) > 0 {
 		o := opts[0]
 		if o.Schedule != nil {
 			req.Schedule = o.Schedule
+		}
+		if o.Instructions != nil {
+			req.Instructions = o.Instructions
+		}
+		if o.Timezone != nil {
+			req.Timezone = o.Timezone
+		}
+		if o.AutoDelete != nil {
+			req.AutoDelete = o.AutoDelete
+		}
+		if o.KeepAgents != nil {
+			req.KeepAgents = o.KeepAgents
+		}
+		if o.Suspended != nil {
+			req.Suspended = o.Suspended
+		}
+		if o.AgentName != nil {
+			req.AgentName = o.AgentName
+		}
+		if o.Agent != nil {
+			req.Agent = o.Agent
 		}
 	}
 	return c.api.SchedulesAPI.PatchSchedule(ctx, name).Request(req).Execute()

--- a/komputer-sdk/go/internal/api/openapi.yaml
+++ b/komputer-sdk/go/internal/api/openapi.yaml
@@ -6131,10 +6131,35 @@ components:
       example:
         instructions: instructions
         schedule: schedule
+        agent:
+          lifecycle: lifecycle
+          role: role
+          templateRef: templateRef
+          model: model
+          secretRefs:
+          - secretRefs
+          - secretRefs
+        timezone: timezone
+        autoDelete: true
+        agentName: agentName
+        keepAgents: true
+        suspended: true
       properties:
+        agent:
+          $ref: "#/components/schemas/CreateScheduleAgentSpec"
+        agentName:
+          type: string
+        autoDelete:
+          type: boolean
         instructions:
           type: string
+        keepAgents:
+          type: boolean
         schedule:
+          type: string
+        suspended:
+          type: boolean
+        timezone:
           type: string
       type: object
     PatchSkillRequest:
@@ -6220,6 +6245,14 @@ components:
         schedules:
         - phase: phase
           instructions: instructions
+          agent:
+            lifecycle: lifecycle
+            role: role
+            templateRef: templateRef
+            model: model
+            secretRefs:
+            - secretRefs
+            - secretRefs
           successfulRuns: 5
           timezone: timezone
           totalCostUSD: totalCostUSD
@@ -6229,6 +6262,7 @@ components:
           lastRunCostUSD: lastRunCostUSD
           totalTokens: 5
           lastRunTokens: 6
+          suspended: true
           createdAt: createdAt
           schedule: schedule
           lastRunTime: lastRunTime
@@ -6240,6 +6274,14 @@ components:
           runCount: 1
         - phase: phase
           instructions: instructions
+          agent:
+            lifecycle: lifecycle
+            role: role
+            templateRef: templateRef
+            model: model
+            secretRefs:
+            - secretRefs
+            - secretRefs
           successfulRuns: 5
           timezone: timezone
           totalCostUSD: totalCostUSD
@@ -6249,6 +6291,7 @@ components:
           lastRunCostUSD: lastRunCostUSD
           totalTokens: 5
           lastRunTokens: 6
+          suspended: true
           createdAt: createdAt
           schedule: schedule
           lastRunTime: lastRunTime
@@ -6268,6 +6311,14 @@ components:
       example:
         phase: phase
         instructions: instructions
+        agent:
+          lifecycle: lifecycle
+          role: role
+          templateRef: templateRef
+          model: model
+          secretRefs:
+          - secretRefs
+          - secretRefs
         successfulRuns: 5
         timezone: timezone
         totalCostUSD: totalCostUSD
@@ -6277,6 +6328,7 @@ components:
         lastRunCostUSD: lastRunCostUSD
         totalTokens: 5
         lastRunTokens: 6
+        suspended: true
         createdAt: createdAt
         schedule: schedule
         lastRunTime: lastRunTime
@@ -6287,6 +6339,8 @@ components:
         keepAgents: true
         runCount: 1
       properties:
+        agent:
+          $ref: "#/components/schemas/CreateScheduleAgentSpec"
         agentName:
           type: string
         autoDelete:
@@ -6321,6 +6375,8 @@ components:
           type: string
         successfulRuns:
           type: integer
+        suspended:
+          type: boolean
         timezone:
           type: string
         totalCostUSD:

--- a/komputer-sdk/go/internal/docs/PatchScheduleRequest.md
+++ b/komputer-sdk/go/internal/docs/PatchScheduleRequest.md
@@ -4,8 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Agent** | Pointer to [**CreateScheduleAgentSpec**](CreateScheduleAgentSpec.md) |  | [optional] 
+**AgentName** | Pointer to **string** |  | [optional] 
+**AutoDelete** | Pointer to **bool** |  | [optional] 
 **Instructions** | Pointer to **string** |  | [optional] 
+**KeepAgents** | Pointer to **bool** |  | [optional] 
 **Schedule** | Pointer to **string** |  | [optional] 
+**Suspended** | Pointer to **bool** |  | [optional] 
+**Timezone** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
@@ -25,6 +31,81 @@ will change when the set of required properties is changed
 NewPatchScheduleRequestWithDefaults instantiates a new PatchScheduleRequest object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetAgent
+
+`func (o *PatchScheduleRequest) GetAgent() CreateScheduleAgentSpec`
+
+GetAgent returns the Agent field if non-nil, zero value otherwise.
+
+### GetAgentOk
+
+`func (o *PatchScheduleRequest) GetAgentOk() (*CreateScheduleAgentSpec, bool)`
+
+GetAgentOk returns a tuple with the Agent field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAgent
+
+`func (o *PatchScheduleRequest) SetAgent(v CreateScheduleAgentSpec)`
+
+SetAgent sets Agent field to given value.
+
+### HasAgent
+
+`func (o *PatchScheduleRequest) HasAgent() bool`
+
+HasAgent returns a boolean if a field has been set.
+
+### GetAgentName
+
+`func (o *PatchScheduleRequest) GetAgentName() string`
+
+GetAgentName returns the AgentName field if non-nil, zero value otherwise.
+
+### GetAgentNameOk
+
+`func (o *PatchScheduleRequest) GetAgentNameOk() (*string, bool)`
+
+GetAgentNameOk returns a tuple with the AgentName field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAgentName
+
+`func (o *PatchScheduleRequest) SetAgentName(v string)`
+
+SetAgentName sets AgentName field to given value.
+
+### HasAgentName
+
+`func (o *PatchScheduleRequest) HasAgentName() bool`
+
+HasAgentName returns a boolean if a field has been set.
+
+### GetAutoDelete
+
+`func (o *PatchScheduleRequest) GetAutoDelete() bool`
+
+GetAutoDelete returns the AutoDelete field if non-nil, zero value otherwise.
+
+### GetAutoDeleteOk
+
+`func (o *PatchScheduleRequest) GetAutoDeleteOk() (*bool, bool)`
+
+GetAutoDeleteOk returns a tuple with the AutoDelete field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAutoDelete
+
+`func (o *PatchScheduleRequest) SetAutoDelete(v bool)`
+
+SetAutoDelete sets AutoDelete field to given value.
+
+### HasAutoDelete
+
+`func (o *PatchScheduleRequest) HasAutoDelete() bool`
+
+HasAutoDelete returns a boolean if a field has been set.
 
 ### GetInstructions
 
@@ -51,6 +132,31 @@ SetInstructions sets Instructions field to given value.
 
 HasInstructions returns a boolean if a field has been set.
 
+### GetKeepAgents
+
+`func (o *PatchScheduleRequest) GetKeepAgents() bool`
+
+GetKeepAgents returns the KeepAgents field if non-nil, zero value otherwise.
+
+### GetKeepAgentsOk
+
+`func (o *PatchScheduleRequest) GetKeepAgentsOk() (*bool, bool)`
+
+GetKeepAgentsOk returns a tuple with the KeepAgents field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetKeepAgents
+
+`func (o *PatchScheduleRequest) SetKeepAgents(v bool)`
+
+SetKeepAgents sets KeepAgents field to given value.
+
+### HasKeepAgents
+
+`func (o *PatchScheduleRequest) HasKeepAgents() bool`
+
+HasKeepAgents returns a boolean if a field has been set.
+
 ### GetSchedule
 
 `func (o *PatchScheduleRequest) GetSchedule() string`
@@ -75,6 +181,56 @@ SetSchedule sets Schedule field to given value.
 `func (o *PatchScheduleRequest) HasSchedule() bool`
 
 HasSchedule returns a boolean if a field has been set.
+
+### GetSuspended
+
+`func (o *PatchScheduleRequest) GetSuspended() bool`
+
+GetSuspended returns the Suspended field if non-nil, zero value otherwise.
+
+### GetSuspendedOk
+
+`func (o *PatchScheduleRequest) GetSuspendedOk() (*bool, bool)`
+
+GetSuspendedOk returns a tuple with the Suspended field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSuspended
+
+`func (o *PatchScheduleRequest) SetSuspended(v bool)`
+
+SetSuspended sets Suspended field to given value.
+
+### HasSuspended
+
+`func (o *PatchScheduleRequest) HasSuspended() bool`
+
+HasSuspended returns a boolean if a field has been set.
+
+### GetTimezone
+
+`func (o *PatchScheduleRequest) GetTimezone() string`
+
+GetTimezone returns the Timezone field if non-nil, zero value otherwise.
+
+### GetTimezoneOk
+
+`func (o *PatchScheduleRequest) GetTimezoneOk() (*string, bool)`
+
+GetTimezoneOk returns a tuple with the Timezone field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetTimezone
+
+`func (o *PatchScheduleRequest) SetTimezone(v string)`
+
+SetTimezone sets Timezone field to given value.
+
+### HasTimezone
+
+`func (o *PatchScheduleRequest) HasTimezone() bool`
+
+HasTimezone returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/komputer-sdk/go/internal/docs/ScheduleResponse.md
+++ b/komputer-sdk/go/internal/docs/ScheduleResponse.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Agent** | Pointer to [**CreateScheduleAgentSpec**](CreateScheduleAgentSpec.md) |  | [optional] 
 **AgentName** | Pointer to **string** |  | [optional] 
 **AutoDelete** | Pointer to **bool** |  | [optional] 
 **CreatedAt** | Pointer to **string** |  | [optional] 
@@ -21,6 +22,7 @@ Name | Type | Description | Notes
 **RunCount** | Pointer to **int32** |  | [optional] 
 **Schedule** | Pointer to **string** |  | [optional] 
 **SuccessfulRuns** | Pointer to **int32** |  | [optional] 
+**Suspended** | Pointer to **bool** |  | [optional] 
 **Timezone** | Pointer to **string** |  | [optional] 
 **TotalCostUSD** | Pointer to **string** |  | [optional] 
 **TotalTokens** | Pointer to **int32** |  | [optional] 
@@ -43,6 +45,31 @@ will change when the set of required properties is changed
 NewScheduleResponseWithDefaults instantiates a new ScheduleResponse object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetAgent
+
+`func (o *ScheduleResponse) GetAgent() CreateScheduleAgentSpec`
+
+GetAgent returns the Agent field if non-nil, zero value otherwise.
+
+### GetAgentOk
+
+`func (o *ScheduleResponse) GetAgentOk() (*CreateScheduleAgentSpec, bool)`
+
+GetAgentOk returns a tuple with the Agent field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAgent
+
+`func (o *ScheduleResponse) SetAgent(v CreateScheduleAgentSpec)`
+
+SetAgent sets Agent field to given value.
+
+### HasAgent
+
+`func (o *ScheduleResponse) HasAgent() bool`
+
+HasAgent returns a boolean if a field has been set.
 
 ### GetAgentName
 
@@ -468,6 +495,31 @@ SetSuccessfulRuns sets SuccessfulRuns field to given value.
 `func (o *ScheduleResponse) HasSuccessfulRuns() bool`
 
 HasSuccessfulRuns returns a boolean if a field has been set.
+
+### GetSuspended
+
+`func (o *ScheduleResponse) GetSuspended() bool`
+
+GetSuspended returns the Suspended field if non-nil, zero value otherwise.
+
+### GetSuspendedOk
+
+`func (o *ScheduleResponse) GetSuspendedOk() (*bool, bool)`
+
+GetSuspendedOk returns a tuple with the Suspended field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSuspended
+
+`func (o *ScheduleResponse) SetSuspended(v bool)`
+
+SetSuspended sets Suspended field to given value.
+
+### HasSuspended
+
+`func (o *ScheduleResponse) HasSuspended() bool`
+
+HasSuspended returns a boolean if a field has been set.
 
 ### GetTimezone
 

--- a/komputer-sdk/go/internal/model_patch_schedule_request.go
+++ b/komputer-sdk/go/internal/model_patch_schedule_request.go
@@ -19,8 +19,14 @@ var _ MappedNullable = &PatchScheduleRequest{}
 
 // PatchScheduleRequest struct for PatchScheduleRequest
 type PatchScheduleRequest struct {
+	Agent *CreateScheduleAgentSpec `json:"agent,omitempty"`
+	AgentName *string `json:"agentName,omitempty"`
+	AutoDelete *bool `json:"autoDelete,omitempty"`
 	Instructions *string `json:"instructions,omitempty"`
+	KeepAgents *bool `json:"keepAgents,omitempty"`
 	Schedule *string `json:"schedule,omitempty"`
+	Suspended *bool `json:"suspended,omitempty"`
+	Timezone *string `json:"timezone,omitempty"`
 }
 
 // NewPatchScheduleRequest instantiates a new PatchScheduleRequest object
@@ -38,6 +44,102 @@ func NewPatchScheduleRequest() *PatchScheduleRequest {
 func NewPatchScheduleRequestWithDefaults() *PatchScheduleRequest {
 	this := PatchScheduleRequest{}
 	return &this
+}
+
+// GetAgent returns the Agent field value if set, zero value otherwise.
+func (o *PatchScheduleRequest) GetAgent() CreateScheduleAgentSpec {
+	if o == nil || IsNil(o.Agent) {
+		var ret CreateScheduleAgentSpec
+		return ret
+	}
+	return *o.Agent
+}
+
+// GetAgentOk returns a tuple with the Agent field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PatchScheduleRequest) GetAgentOk() (*CreateScheduleAgentSpec, bool) {
+	if o == nil || IsNil(o.Agent) {
+		return nil, false
+	}
+	return o.Agent, true
+}
+
+// HasAgent returns a boolean if a field has been set.
+func (o *PatchScheduleRequest) HasAgent() bool {
+	if o != nil && !IsNil(o.Agent) {
+		return true
+	}
+
+	return false
+}
+
+// SetAgent gets a reference to the given CreateScheduleAgentSpec and assigns it to the Agent field.
+func (o *PatchScheduleRequest) SetAgent(v CreateScheduleAgentSpec) {
+	o.Agent = &v
+}
+
+// GetAgentName returns the AgentName field value if set, zero value otherwise.
+func (o *PatchScheduleRequest) GetAgentName() string {
+	if o == nil || IsNil(o.AgentName) {
+		var ret string
+		return ret
+	}
+	return *o.AgentName
+}
+
+// GetAgentNameOk returns a tuple with the AgentName field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PatchScheduleRequest) GetAgentNameOk() (*string, bool) {
+	if o == nil || IsNil(o.AgentName) {
+		return nil, false
+	}
+	return o.AgentName, true
+}
+
+// HasAgentName returns a boolean if a field has been set.
+func (o *PatchScheduleRequest) HasAgentName() bool {
+	if o != nil && !IsNil(o.AgentName) {
+		return true
+	}
+
+	return false
+}
+
+// SetAgentName gets a reference to the given string and assigns it to the AgentName field.
+func (o *PatchScheduleRequest) SetAgentName(v string) {
+	o.AgentName = &v
+}
+
+// GetAutoDelete returns the AutoDelete field value if set, zero value otherwise.
+func (o *PatchScheduleRequest) GetAutoDelete() bool {
+	if o == nil || IsNil(o.AutoDelete) {
+		var ret bool
+		return ret
+	}
+	return *o.AutoDelete
+}
+
+// GetAutoDeleteOk returns a tuple with the AutoDelete field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PatchScheduleRequest) GetAutoDeleteOk() (*bool, bool) {
+	if o == nil || IsNil(o.AutoDelete) {
+		return nil, false
+	}
+	return o.AutoDelete, true
+}
+
+// HasAutoDelete returns a boolean if a field has been set.
+func (o *PatchScheduleRequest) HasAutoDelete() bool {
+	if o != nil && !IsNil(o.AutoDelete) {
+		return true
+	}
+
+	return false
+}
+
+// SetAutoDelete gets a reference to the given bool and assigns it to the AutoDelete field.
+func (o *PatchScheduleRequest) SetAutoDelete(v bool) {
+	o.AutoDelete = &v
 }
 
 // GetInstructions returns the Instructions field value if set, zero value otherwise.
@@ -72,6 +174,38 @@ func (o *PatchScheduleRequest) SetInstructions(v string) {
 	o.Instructions = &v
 }
 
+// GetKeepAgents returns the KeepAgents field value if set, zero value otherwise.
+func (o *PatchScheduleRequest) GetKeepAgents() bool {
+	if o == nil || IsNil(o.KeepAgents) {
+		var ret bool
+		return ret
+	}
+	return *o.KeepAgents
+}
+
+// GetKeepAgentsOk returns a tuple with the KeepAgents field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PatchScheduleRequest) GetKeepAgentsOk() (*bool, bool) {
+	if o == nil || IsNil(o.KeepAgents) {
+		return nil, false
+	}
+	return o.KeepAgents, true
+}
+
+// HasKeepAgents returns a boolean if a field has been set.
+func (o *PatchScheduleRequest) HasKeepAgents() bool {
+	if o != nil && !IsNil(o.KeepAgents) {
+		return true
+	}
+
+	return false
+}
+
+// SetKeepAgents gets a reference to the given bool and assigns it to the KeepAgents field.
+func (o *PatchScheduleRequest) SetKeepAgents(v bool) {
+	o.KeepAgents = &v
+}
+
 // GetSchedule returns the Schedule field value if set, zero value otherwise.
 func (o *PatchScheduleRequest) GetSchedule() string {
 	if o == nil || IsNil(o.Schedule) {
@@ -104,6 +238,70 @@ func (o *PatchScheduleRequest) SetSchedule(v string) {
 	o.Schedule = &v
 }
 
+// GetSuspended returns the Suspended field value if set, zero value otherwise.
+func (o *PatchScheduleRequest) GetSuspended() bool {
+	if o == nil || IsNil(o.Suspended) {
+		var ret bool
+		return ret
+	}
+	return *o.Suspended
+}
+
+// GetSuspendedOk returns a tuple with the Suspended field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PatchScheduleRequest) GetSuspendedOk() (*bool, bool) {
+	if o == nil || IsNil(o.Suspended) {
+		return nil, false
+	}
+	return o.Suspended, true
+}
+
+// HasSuspended returns a boolean if a field has been set.
+func (o *PatchScheduleRequest) HasSuspended() bool {
+	if o != nil && !IsNil(o.Suspended) {
+		return true
+	}
+
+	return false
+}
+
+// SetSuspended gets a reference to the given bool and assigns it to the Suspended field.
+func (o *PatchScheduleRequest) SetSuspended(v bool) {
+	o.Suspended = &v
+}
+
+// GetTimezone returns the Timezone field value if set, zero value otherwise.
+func (o *PatchScheduleRequest) GetTimezone() string {
+	if o == nil || IsNil(o.Timezone) {
+		var ret string
+		return ret
+	}
+	return *o.Timezone
+}
+
+// GetTimezoneOk returns a tuple with the Timezone field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PatchScheduleRequest) GetTimezoneOk() (*string, bool) {
+	if o == nil || IsNil(o.Timezone) {
+		return nil, false
+	}
+	return o.Timezone, true
+}
+
+// HasTimezone returns a boolean if a field has been set.
+func (o *PatchScheduleRequest) HasTimezone() bool {
+	if o != nil && !IsNil(o.Timezone) {
+		return true
+	}
+
+	return false
+}
+
+// SetTimezone gets a reference to the given string and assigns it to the Timezone field.
+func (o *PatchScheduleRequest) SetTimezone(v string) {
+	o.Timezone = &v
+}
+
 func (o PatchScheduleRequest) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -114,11 +312,29 @@ func (o PatchScheduleRequest) MarshalJSON() ([]byte, error) {
 
 func (o PatchScheduleRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.Agent) {
+		toSerialize["agent"] = o.Agent
+	}
+	if !IsNil(o.AgentName) {
+		toSerialize["agentName"] = o.AgentName
+	}
+	if !IsNil(o.AutoDelete) {
+		toSerialize["autoDelete"] = o.AutoDelete
+	}
 	if !IsNil(o.Instructions) {
 		toSerialize["instructions"] = o.Instructions
 	}
+	if !IsNil(o.KeepAgents) {
+		toSerialize["keepAgents"] = o.KeepAgents
+	}
 	if !IsNil(o.Schedule) {
 		toSerialize["schedule"] = o.Schedule
+	}
+	if !IsNil(o.Suspended) {
+		toSerialize["suspended"] = o.Suspended
+	}
+	if !IsNil(o.Timezone) {
+		toSerialize["timezone"] = o.Timezone
 	}
 	return toSerialize, nil
 }

--- a/komputer-sdk/go/internal/model_schedule_response.go
+++ b/komputer-sdk/go/internal/model_schedule_response.go
@@ -19,6 +19,7 @@ var _ MappedNullable = &ScheduleResponse{}
 
 // ScheduleResponse struct for ScheduleResponse
 type ScheduleResponse struct {
+	Agent *CreateScheduleAgentSpec `json:"agent,omitempty"`
 	AgentName *string `json:"agentName,omitempty"`
 	AutoDelete *bool `json:"autoDelete,omitempty"`
 	CreatedAt *string `json:"createdAt,omitempty"`
@@ -36,6 +37,7 @@ type ScheduleResponse struct {
 	RunCount *int32 `json:"runCount,omitempty"`
 	Schedule *string `json:"schedule,omitempty"`
 	SuccessfulRuns *int32 `json:"successfulRuns,omitempty"`
+	Suspended *bool `json:"suspended,omitempty"`
 	Timezone *string `json:"timezone,omitempty"`
 	TotalCostUSD *string `json:"totalCostUSD,omitempty"`
 	TotalTokens *int32 `json:"totalTokens,omitempty"`
@@ -56,6 +58,38 @@ func NewScheduleResponse() *ScheduleResponse {
 func NewScheduleResponseWithDefaults() *ScheduleResponse {
 	this := ScheduleResponse{}
 	return &this
+}
+
+// GetAgent returns the Agent field value if set, zero value otherwise.
+func (o *ScheduleResponse) GetAgent() CreateScheduleAgentSpec {
+	if o == nil || IsNil(o.Agent) {
+		var ret CreateScheduleAgentSpec
+		return ret
+	}
+	return *o.Agent
+}
+
+// GetAgentOk returns a tuple with the Agent field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ScheduleResponse) GetAgentOk() (*CreateScheduleAgentSpec, bool) {
+	if o == nil || IsNil(o.Agent) {
+		return nil, false
+	}
+	return o.Agent, true
+}
+
+// HasAgent returns a boolean if a field has been set.
+func (o *ScheduleResponse) HasAgent() bool {
+	if o != nil && !IsNil(o.Agent) {
+		return true
+	}
+
+	return false
+}
+
+// SetAgent gets a reference to the given CreateScheduleAgentSpec and assigns it to the Agent field.
+func (o *ScheduleResponse) SetAgent(v CreateScheduleAgentSpec) {
+	o.Agent = &v
 }
 
 // GetAgentName returns the AgentName field value if set, zero value otherwise.
@@ -602,6 +636,38 @@ func (o *ScheduleResponse) SetSuccessfulRuns(v int32) {
 	o.SuccessfulRuns = &v
 }
 
+// GetSuspended returns the Suspended field value if set, zero value otherwise.
+func (o *ScheduleResponse) GetSuspended() bool {
+	if o == nil || IsNil(o.Suspended) {
+		var ret bool
+		return ret
+	}
+	return *o.Suspended
+}
+
+// GetSuspendedOk returns a tuple with the Suspended field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ScheduleResponse) GetSuspendedOk() (*bool, bool) {
+	if o == nil || IsNil(o.Suspended) {
+		return nil, false
+	}
+	return o.Suspended, true
+}
+
+// HasSuspended returns a boolean if a field has been set.
+func (o *ScheduleResponse) HasSuspended() bool {
+	if o != nil && !IsNil(o.Suspended) {
+		return true
+	}
+
+	return false
+}
+
+// SetSuspended gets a reference to the given bool and assigns it to the Suspended field.
+func (o *ScheduleResponse) SetSuspended(v bool) {
+	o.Suspended = &v
+}
+
 // GetTimezone returns the Timezone field value if set, zero value otherwise.
 func (o *ScheduleResponse) GetTimezone() string {
 	if o == nil || IsNil(o.Timezone) {
@@ -708,6 +774,9 @@ func (o ScheduleResponse) MarshalJSON() ([]byte, error) {
 
 func (o ScheduleResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.Agent) {
+		toSerialize["agent"] = o.Agent
+	}
 	if !IsNil(o.AgentName) {
 		toSerialize["agentName"] = o.AgentName
 	}
@@ -758,6 +827,9 @@ func (o ScheduleResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.SuccessfulRuns) {
 		toSerialize["successfulRuns"] = o.SuccessfulRuns
+	}
+	if !IsNil(o.Suspended) {
+		toSerialize["suspended"] = o.Suspended
 	}
 	if !IsNil(o.Timezone) {
 		toSerialize["timezone"] = o.Timezone

--- a/komputer-sdk/openapi.yaml
+++ b/komputer-sdk/openapi.yaml
@@ -4223,6 +4223,14 @@ components:
       - name
       type: object
     CreateScheduleAgentSpec:
+      example:
+        lifecycle: lifecycle
+        role: role
+        templateRef: templateRef
+        model: model
+        secretRefs:
+        - secretRefs
+        - secretRefs
       properties:
         lifecycle:
           type: string
@@ -4501,9 +4509,21 @@ components:
       type: object
     PatchScheduleRequest:
       properties:
+        agent:
+          $ref: "#/components/schemas/CreateScheduleAgentSpec"
+        agentName:
+          type: string
+        autoDelete:
+          type: boolean
         instructions:
           type: string
+        keepAgents:
+          type: boolean
         schedule:
+          type: string
+        suspended:
+          type: boolean
+        timezone:
           type: string
       type: object
     PatchSkillRequest:
@@ -4527,6 +4547,14 @@ components:
         schedules:
         - phase: phase
           instructions: instructions
+          agent:
+            lifecycle: lifecycle
+            role: role
+            templateRef: templateRef
+            model: model
+            secretRefs:
+            - secretRefs
+            - secretRefs
           successfulRuns: 5
           timezone: timezone
           totalCostUSD: totalCostUSD
@@ -4536,6 +4564,7 @@ components:
           lastRunCostUSD: lastRunCostUSD
           totalTokens: 5
           lastRunTokens: 6
+          suspended: true
           createdAt: createdAt
           schedule: schedule
           lastRunTime: lastRunTime
@@ -4547,6 +4576,14 @@ components:
           runCount: 1
         - phase: phase
           instructions: instructions
+          agent:
+            lifecycle: lifecycle
+            role: role
+            templateRef: templateRef
+            model: model
+            secretRefs:
+            - secretRefs
+            - secretRefs
           successfulRuns: 5
           timezone: timezone
           totalCostUSD: totalCostUSD
@@ -4556,6 +4593,7 @@ components:
           lastRunCostUSD: lastRunCostUSD
           totalTokens: 5
           lastRunTokens: 6
+          suspended: true
           createdAt: createdAt
           schedule: schedule
           lastRunTime: lastRunTime
@@ -4575,6 +4613,14 @@ components:
       example:
         phase: phase
         instructions: instructions
+        agent:
+          lifecycle: lifecycle
+          role: role
+          templateRef: templateRef
+          model: model
+          secretRefs:
+          - secretRefs
+          - secretRefs
         successfulRuns: 5
         timezone: timezone
         totalCostUSD: totalCostUSD
@@ -4584,6 +4630,7 @@ components:
         lastRunCostUSD: lastRunCostUSD
         totalTokens: 5
         lastRunTokens: 6
+        suspended: true
         createdAt: createdAt
         schedule: schedule
         lastRunTime: lastRunTime
@@ -4594,6 +4641,8 @@ components:
         keepAgents: true
         runCount: 1
       properties:
+        agent:
+          $ref: "#/components/schemas/CreateScheduleAgentSpec"
         agentName:
           type: string
         autoDelete:
@@ -4628,6 +4677,8 @@ components:
           type: string
         successfulRuns:
           type: integer
+        suspended:
+          type: boolean
         timezone:
           type: string
         totalCostUSD:

--- a/komputer-sdk/python/komputer_ai/client.py
+++ b/komputer-sdk/python/komputer_ai/client.py
@@ -140,8 +140,8 @@ class KomputerClient:
     def get_schedule(self, name: str):
         return self.schedules.get_schedule(name)
 
-    def patch_schedule(self, name: str, *, schedule: Optional[str] = None):
-        return self.schedules.patch_schedule(name, PatchScheduleRequest(schedule=schedule))
+    def patch_schedule(self, name: str, *, schedule: Optional[str] = None, instructions: Optional[str] = None, timezone: Optional[str] = None, auto_delete: Optional[bool] = None, keep_agents: Optional[bool] = None, suspended: Optional[bool] = None, agent_name: Optional[str] = None, agent: Optional[CreateScheduleAgentSpec] = None):
+        return self.schedules.patch_schedule(name, PatchScheduleRequest(schedule=schedule, instructions=instructions, timezone=timezone, auto_delete=auto_delete, keep_agents=keep_agents, suspended=suspended, agent_name=agent_name, agent=agent))
 
     def delete_schedule(self, name: str):
         return self.schedules.delete_schedule(name)

--- a/komputer-sdk/typescript/docs/PatchScheduleRequest.md
+++ b/komputer-sdk/typescript/docs/PatchScheduleRequest.md
@@ -6,8 +6,14 @@
 
 Name | Type
 ------------ | -------------
+`agent` | [CreateScheduleAgentSpec](CreateScheduleAgentSpec.md)
+`agentName` | string
+`autoDelete` | boolean
 `instructions` | string
+`keepAgents` | boolean
 `schedule` | string
+`suspended` | boolean
+`timezone` | string
 
 ## Example
 
@@ -16,8 +22,14 @@ import type { PatchScheduleRequest } from '@komputer-ai/sdk'
 
 // TODO: Update the object below with actual values
 const example = {
+  "agent": null,
+  "agentName": null,
+  "autoDelete": null,
   "instructions": null,
+  "keepAgents": null,
   "schedule": null,
+  "suspended": null,
+  "timezone": null,
 } satisfies PatchScheduleRequest
 
 console.log(example)

--- a/komputer-sdk/typescript/docs/ScheduleResponse.md
+++ b/komputer-sdk/typescript/docs/ScheduleResponse.md
@@ -6,6 +6,7 @@
 
 Name | Type
 ------------ | -------------
+`agent` | [CreateScheduleAgentSpec](CreateScheduleAgentSpec.md)
 `agentName` | string
 `autoDelete` | boolean
 `createdAt` | string
@@ -23,6 +24,7 @@ Name | Type
 `runCount` | number
 `schedule` | string
 `successfulRuns` | number
+`suspended` | boolean
 `timezone` | string
 `totalCostUSD` | string
 `totalTokens` | number
@@ -34,6 +36,7 @@ import type { ScheduleResponse } from '@komputer-ai/sdk'
 
 // TODO: Update the object below with actual values
 const example = {
+  "agent": null,
   "agentName": null,
   "autoDelete": null,
   "createdAt": null,
@@ -51,6 +54,7 @@ const example = {
   "runCount": null,
   "schedule": null,
   "successfulRuns": null,
+  "suspended": null,
   "timezone": null,
   "totalCostUSD": null,
   "totalTokens": null,

--- a/komputer-sdk/typescript/src/client.ts
+++ b/komputer-sdk/typescript/src/client.ts
@@ -159,8 +159,30 @@ export class KomputerClient {
     return this._schedules.getSchedule({ name });
   }
 
-  async patchSchedule(params: { name: string; schedule?: string }) {
-    return this._schedules.patchSchedule({ name: params.name, request: { schedule: params.schedule } });
+  async patchSchedule(params: {
+    name: string;
+    schedule?: string;
+    instructions?: string;
+    timezone?: string;
+    autoDelete?: boolean;
+    keepAgents?: boolean;
+    suspended?: boolean;
+    agentName?: string;
+    agent?: CreateScheduleAgentSpec;
+  }) {
+    return this._schedules.patchSchedule({
+      name: params.name,
+      request: {
+        schedule: params.schedule,
+        instructions: params.instructions,
+        timezone: params.timezone,
+        autoDelete: params.autoDelete,
+        keepAgents: params.keepAgents,
+        suspended: params.suspended,
+        agentName: params.agentName,
+        agent: params.agent,
+      },
+    });
   }
 
   async deleteSchedule(name: string) {

--- a/komputer-sdk/typescript/src/models/PatchScheduleRequest.ts
+++ b/komputer-sdk/typescript/src/models/PatchScheduleRequest.ts
@@ -13,6 +13,14 @@
  */
 
 import { mapValues } from '../runtime';
+import type { CreateScheduleAgentSpec } from './CreateScheduleAgentSpec';
+import {
+    CreateScheduleAgentSpecFromJSON,
+    CreateScheduleAgentSpecFromJSONTyped,
+    CreateScheduleAgentSpecToJSON,
+    CreateScheduleAgentSpecToJSONTyped,
+} from './CreateScheduleAgentSpec';
+
 /**
  * 
  * @export
@@ -21,16 +29,52 @@ import { mapValues } from '../runtime';
 export interface PatchScheduleRequest {
     /**
      * 
+     * @type {CreateScheduleAgentSpec}
+     * @memberof PatchScheduleRequest
+     */
+    agent?: CreateScheduleAgentSpec;
+    /**
+     * 
+     * @type {string}
+     * @memberof PatchScheduleRequest
+     */
+    agentName?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof PatchScheduleRequest
+     */
+    autoDelete?: boolean;
+    /**
+     * 
      * @type {string}
      * @memberof PatchScheduleRequest
      */
     instructions?: string;
     /**
      * 
+     * @type {boolean}
+     * @memberof PatchScheduleRequest
+     */
+    keepAgents?: boolean;
+    /**
+     * 
      * @type {string}
      * @memberof PatchScheduleRequest
      */
     schedule?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof PatchScheduleRequest
+     */
+    suspended?: boolean;
+    /**
+     * 
+     * @type {string}
+     * @memberof PatchScheduleRequest
+     */
+    timezone?: string;
 }
 
 /**
@@ -50,8 +94,14 @@ export function PatchScheduleRequestFromJSONTyped(json: any, ignoreDiscriminator
     }
     return {
         
+        'agent': json['agent'] == null ? undefined : CreateScheduleAgentSpecFromJSON(json['agent']),
+        'agentName': json['agentName'] == null ? undefined : json['agentName'],
+        'autoDelete': json['autoDelete'] == null ? undefined : json['autoDelete'],
         'instructions': json['instructions'] == null ? undefined : json['instructions'],
+        'keepAgents': json['keepAgents'] == null ? undefined : json['keepAgents'],
         'schedule': json['schedule'] == null ? undefined : json['schedule'],
+        'suspended': json['suspended'] == null ? undefined : json['suspended'],
+        'timezone': json['timezone'] == null ? undefined : json['timezone'],
     };
 }
 
@@ -66,8 +116,14 @@ export function PatchScheduleRequestToJSONTyped(value?: PatchScheduleRequest | n
 
     return {
         
+        'agent': CreateScheduleAgentSpecToJSON(value['agent']),
+        'agentName': value['agentName'],
+        'autoDelete': value['autoDelete'],
         'instructions': value['instructions'],
+        'keepAgents': value['keepAgents'],
         'schedule': value['schedule'],
+        'suspended': value['suspended'],
+        'timezone': value['timezone'],
     };
 }
 

--- a/komputer-sdk/typescript/src/models/ScheduleResponse.ts
+++ b/komputer-sdk/typescript/src/models/ScheduleResponse.ts
@@ -13,12 +13,26 @@
  */
 
 import { mapValues } from '../runtime';
+import type { CreateScheduleAgentSpec } from './CreateScheduleAgentSpec';
+import {
+    CreateScheduleAgentSpecFromJSON,
+    CreateScheduleAgentSpecFromJSONTyped,
+    CreateScheduleAgentSpecToJSON,
+    CreateScheduleAgentSpecToJSONTyped,
+} from './CreateScheduleAgentSpec';
+
 /**
  * 
  * @export
  * @interface ScheduleResponse
  */
 export interface ScheduleResponse {
+    /**
+     * 
+     * @type {CreateScheduleAgentSpec}
+     * @memberof ScheduleResponse
+     */
+    agent?: CreateScheduleAgentSpec;
     /**
      * 
      * @type {string}
@@ -123,6 +137,12 @@ export interface ScheduleResponse {
     successfulRuns?: number;
     /**
      * 
+     * @type {boolean}
+     * @memberof ScheduleResponse
+     */
+    suspended?: boolean;
+    /**
+     * 
      * @type {string}
      * @memberof ScheduleResponse
      */
@@ -158,6 +178,7 @@ export function ScheduleResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     }
     return {
         
+        'agent': json['agent'] == null ? undefined : CreateScheduleAgentSpecFromJSON(json['agent']),
         'agentName': json['agentName'] == null ? undefined : json['agentName'],
         'autoDelete': json['autoDelete'] == null ? undefined : json['autoDelete'],
         'createdAt': json['createdAt'] == null ? undefined : json['createdAt'],
@@ -175,6 +196,7 @@ export function ScheduleResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'runCount': json['runCount'] == null ? undefined : json['runCount'],
         'schedule': json['schedule'] == null ? undefined : json['schedule'],
         'successfulRuns': json['successfulRuns'] == null ? undefined : json['successfulRuns'],
+        'suspended': json['suspended'] == null ? undefined : json['suspended'],
         'timezone': json['timezone'] == null ? undefined : json['timezone'],
         'totalCostUSD': json['totalCostUSD'] == null ? undefined : json['totalCostUSD'],
         'totalTokens': json['totalTokens'] == null ? undefined : json['totalTokens'],
@@ -192,6 +214,7 @@ export function ScheduleResponseToJSONTyped(value?: ScheduleResponse | null, ign
 
     return {
         
+        'agent': CreateScheduleAgentSpecToJSON(value['agent']),
         'agentName': value['agentName'],
         'autoDelete': value['autoDelete'],
         'createdAt': value['createdAt'],
@@ -209,6 +232,7 @@ export function ScheduleResponseToJSONTyped(value?: ScheduleResponse | null, ign
         'runCount': value['runCount'],
         'schedule': value['schedule'],
         'successfulRuns': value['successfulRuns'],
+        'suspended': value['suspended'],
         'timezone': value['timezone'],
         'totalCostUSD': value['totalCostUSD'],
         'totalTokens': value['totalTokens'],

--- a/komputer-ui/src/app/schedules/[name]/page.tsx
+++ b/komputer-ui/src/app/schedules/[name]/page.tsx
@@ -4,20 +4,21 @@ import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
-import { Trash2, Calendar, CheckCircle, DollarSign, Activity, Pencil, Check, X, Clock, Play } from "lucide-react";
+import { Trash2, Calendar, CheckCircle, DollarSign, Activity, Pencil, Check, X, Clock, Play, Pause, Save } from "lucide-react";
 
 import { Button } from "@/components/kit/button";
 import { Badge } from "@/components/kit/badge";
 import { StatusBadge } from "@/components/shared/status-badge";
-import { CostBadge } from "@/components/shared/cost-badge";
 import { RelativeTime } from "@/components/shared/relative-time";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
 import { SkeletonTable } from "@/components/shared/loading-skeleton";
-import { Input } from "@/components/kit/input";
-import { getSchedule, deleteSchedule, patchSchedule, triggerSchedule } from "@/lib/api";
+import { Label } from "@/components/kit/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/kit/select";
+import { getSchedule, deleteSchedule, patchSchedule, triggerSchedule, listAgents } from "@/lib/api";
 import { useDelayedLoading } from "@/hooks/use-delayed-loading";
 import { cronToHuman, formatCost } from "@/lib/utils";
-import type { ScheduleResponse } from "@/lib/types";
+import { LIFECYCLES, MODELS } from "@/lib/constants";
+import type { ScheduleResponse, PatchScheduleRequest } from "@/lib/types";
 
 function StatCard({
   label,
@@ -60,6 +61,22 @@ export default function ScheduleDetailPage() {
   const [savingInstructions, setSavingInstructions] = useState(false);
   const [triggering, setTriggering] = useState(false);
   const [triggerMessage, setTriggerMessage] = useState<string | null>(null);
+  // Inline editor for the "Details" panel — covers agent target, timezone,
+  // flags, suspended toggle, and the inline ScheduleAgentSpec template.
+  const [editingDetails, setEditingDetails] = useState(false);
+  const [savingDetails, setSavingDetails] = useState(false);
+  const [detailsDraft, setDetailsDraft] = useState<{
+    agentName: string;
+    timezone: string;
+    autoDelete: boolean;
+    keepAgents: boolean;
+    suspended: boolean;
+    agentModel: string;
+    agentLifecycle: string;
+    agentRole: string;
+    agentTemplateRef: string;
+  } | null>(null);
+  const [availableAgents, setAvailableAgents] = useState<{ name: string; namespace?: string }[]>([]);
 
   const fetchData = useCallback(async () => {
     try {
@@ -80,6 +97,94 @@ export default function ScheduleDetailPage() {
     const interval = setInterval(fetchData, 10_000);
     return () => clearInterval(interval);
   }, [fetchData]);
+
+  // Load the agent list lazily — only when the user opens the editor.
+  useEffect(() => {
+    if (!editingDetails || availableAgents.length > 0) return;
+    listAgents()
+      .then((res) =>
+        setAvailableAgents(
+          (res.agents ?? []).map((a) => ({ name: a.name, namespace: a.namespace }))
+        )
+      )
+      .catch(() => {
+        /* non-critical */
+      });
+  }, [editingDetails, availableAgents.length]);
+
+  function openDetailsEditor() {
+    if (!schedule) return;
+    setDetailsDraft({
+      agentName: schedule.agentName ?? "",
+      timezone: schedule.timezone ?? "",
+      autoDelete: !!schedule.autoDelete,
+      keepAgents: !!schedule.keepAgents,
+      suspended: !!schedule.suspended,
+      agentModel: schedule.agent?.model ?? "",
+      agentLifecycle: schedule.agent?.lifecycle || "Sleep",
+      agentRole: schedule.agent?.role ?? "",
+      agentTemplateRef: schedule.agent?.templateRef ?? "",
+    });
+    setEditingDetails(true);
+  }
+
+  async function handleSaveDetails() {
+    if (!schedule || !detailsDraft) return;
+    const patch: PatchScheduleRequest = {};
+    const draftAgent = detailsDraft.agentName.trim();
+    const currentAgent = schedule.agentName ?? "";
+    if (draftAgent !== currentAgent) patch.agentName = draftAgent;
+    if (detailsDraft.timezone !== (schedule.timezone ?? ""))
+      patch.timezone = detailsDraft.timezone;
+    if (detailsDraft.autoDelete !== !!schedule.autoDelete)
+      patch.autoDelete = detailsDraft.autoDelete;
+    if (detailsDraft.keepAgents !== !!schedule.keepAgents)
+      patch.keepAgents = detailsDraft.keepAgents;
+    if (detailsDraft.suspended !== !!schedule.suspended)
+      patch.suspended = detailsDraft.suspended;
+    // Inline agent template — only send when no agentName is set and at least one field differs.
+    if (!draftAgent) {
+      const cur = schedule.agent ?? {};
+      const next = {
+        model: detailsDraft.agentModel,
+        lifecycle: detailsDraft.agentLifecycle,
+        role: detailsDraft.agentRole,
+        templateRef: detailsDraft.agentTemplateRef,
+      };
+      if (
+        (cur.model ?? "") !== next.model ||
+        (cur.lifecycle ?? "") !== next.lifecycle ||
+        (cur.role ?? "") !== next.role ||
+        (cur.templateRef ?? "") !== next.templateRef
+      ) {
+        patch.agent = next;
+      }
+    }
+    if (Object.keys(patch).length === 0) {
+      setEditingDetails(false);
+      return;
+    }
+    setSavingDetails(true);
+    try {
+      await patchSchedule(name, patch, scheduleNs);
+      await fetchData();
+      setEditingDetails(false);
+    } catch {
+      // keep editing open on error
+    } finally {
+      setSavingDetails(false);
+    }
+  }
+
+  async function handleToggleSuspended() {
+    if (!schedule) return;
+    try {
+      await patchSchedule(name, { suspended: !schedule.suspended }, scheduleNs);
+      await fetchData();
+    } catch {
+      /* non-critical */
+    }
+  }
 
   async function handleDelete() {
     try {
@@ -207,10 +312,25 @@ export default function ScheduleDetailPage() {
             {triggerMessage && (
               <span className="text-xs text-[var(--color-text-secondary)]">{triggerMessage}</span>
             )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleToggleSuspended}
+              title={schedule.suspended ? "Resume scheduled runs" : "Pause without deleting"}
+            >
+              {schedule.suspended ? (
+                <Play className="size-3.5 text-emerald-400" />
+              ) : (
+                <Pause className="size-3.5 text-[var(--color-text-secondary)]" />
+              )}
+              {schedule.suspended ? "Resume" : "Suspend"}
+            </Button>
             <ConfirmDialog
               title={`Run ${schedule.name} now?`}
               description="This triggers the schedule's instructions immediately, outside of its cron cadence."
               onConfirm={handleTrigger}
+              confirmLabel="Run now"
+              confirmVariant="primary"
               trigger={
                 <Button
                   variant="ghost"
@@ -401,94 +521,304 @@ export default function ScheduleDetailPage() {
 
         <div className="border-t border-[var(--color-border)]" />
 
-        {/* Info section */}
+        {/* Info / Details section — view + inline editor */}
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
-            Details
-          </h2>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {/* Agent */}
-            <div>
-              <span className="text-xs text-[var(--color-text-secondary)]">
-                Agent
-              </span>
-              <p className="mt-0.5">
-                {schedule.agentName ? (
-                  <Link
-                    href={`/agents/${schedule.agentName}?namespace=${schedule.namespace}`}
-                    className="text-sm font-medium text-[var(--color-brand-blue)] hover:underline"
-                  >
-                    {schedule.agentName}
-                  </Link>
-                ) : (
-                  <span className="text-sm text-[var(--color-text-secondary)]">
-                    --
-                  </span>
-                )}
-              </p>
-            </div>
-
-            {/* Next run */}
-            <div>
-              <span className="text-xs text-[var(--color-text-secondary)]">
-                Next Run
-              </span>
-              <p className="mt-0.5">
-                {schedule.nextRunTime ? (
-                  <RelativeTime timestamp={schedule.nextRunTime} />
-                ) : (
-                  <span className="text-sm text-[var(--color-text-secondary)]">
-                    --
-                  </span>
-                )}
-              </p>
-            </div>
-
-            {/* Last run */}
-            <div>
-              <span className="text-xs text-[var(--color-text-secondary)]">
-                Last Run
-              </span>
-              <div className="mt-0.5 flex items-center gap-2">
-                {schedule.lastRunTime ? (
-                  <>
-                    <RelativeTime timestamp={schedule.lastRunTime} />
-                    {schedule.lastRunStatus && (
-                      <StatusBadge status={schedule.lastRunStatus} size="sm" />
-                    )}
-                  </>
-                ) : (
-                  <span className="text-sm text-[var(--color-text-secondary)]">
-                    --
-                  </span>
-                )}
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
+              Details
+            </h2>
+            {!editingDetails ? (
+              <Button variant="ghost" size="sm" onClick={openDetailsEditor}>
+                <Pencil className="size-3 text-[var(--color-text-muted)]" />
+                Edit
+              </Button>
+            ) : (
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleSaveDetails}
+                  disabled={savingDetails}
+                >
+                  <Save className="size-3.5" />
+                  {savingDetails ? "Saving..." : "Save"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setEditingDetails(false)}
+                  disabled={savingDetails}
+                >
+                  <X className="size-3.5" />
+                  Cancel
+                </Button>
               </div>
-            </div>
-
-            {/* Flags */}
-            <div>
-              <span className="text-xs text-[var(--color-text-secondary)]">
-                Flags
-              </span>
-              <div className="mt-0.5 flex items-center gap-2">
-                {schedule.autoDelete ? (
-                  <Badge variant="secondary" className="text-[10px]">
-                    Auto-delete
-                  </Badge>
-                ) : null}
-                {schedule.keepAgents ? (
-                  <Badge variant="secondary" className="text-[10px]">
-                    Keep agents
-                  </Badge>
-                ) : null}
-                {!schedule.autoDelete && !schedule.keepAgents && (
-                  <span className="text-sm text-[var(--color-text-secondary)]">
-                    --
-                  </span>
-                )}
-              </div>
-            </div>
+            )}
           </div>
+
+          {!editingDetails || !detailsDraft ? (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {/* Agent */}
+              <div>
+                <span className="text-xs text-[var(--color-text-secondary)]">Agent</span>
+                <p className="mt-0.5">
+                  {schedule.agentName ? (
+                    <Link
+                      href={`/agents/${schedule.agentName}?namespace=${schedule.namespace}`}
+                      className="text-sm font-medium text-[var(--color-brand-blue)] hover:underline"
+                    >
+                      {schedule.agentName}
+                    </Link>
+                  ) : schedule.agent ? (
+                    <span className="text-sm text-[var(--color-text)]">
+                      New agent · {schedule.agent.model || "default model"}
+                      {schedule.agent.lifecycle ? ` · ${schedule.agent.lifecycle}` : ""}
+                    </span>
+                  ) : (
+                    <span className="text-sm text-[var(--color-text-secondary)]">--</span>
+                  )}
+                </p>
+              </div>
+
+              {/* Timezone */}
+              <div>
+                <span className="text-xs text-[var(--color-text-secondary)]">Timezone</span>
+                <p className="mt-0.5 text-sm text-[var(--color-text)]">
+                  {schedule.timezone || "UTC"}
+                </p>
+              </div>
+
+              {/* Next run */}
+              <div>
+                <span className="text-xs text-[var(--color-text-secondary)]">Next Run</span>
+                <p className="mt-0.5">
+                  {schedule.nextRunTime ? (
+                    <RelativeTime timestamp={schedule.nextRunTime} />
+                  ) : (
+                    <span className="text-sm text-[var(--color-text-secondary)]">--</span>
+                  )}
+                </p>
+              </div>
+
+              {/* Last run */}
+              <div>
+                <span className="text-xs text-[var(--color-text-secondary)]">Last Run</span>
+                <div className="mt-0.5 flex items-center gap-2">
+                  {schedule.lastRunTime ? (
+                    <>
+                      <RelativeTime timestamp={schedule.lastRunTime} />
+                      {schedule.lastRunStatus && (
+                        <StatusBadge status={schedule.lastRunStatus} size="sm" />
+                      )}
+                    </>
+                  ) : (
+                    <span className="text-sm text-[var(--color-text-secondary)]">--</span>
+                  )}
+                </div>
+              </div>
+
+              {/* Flags */}
+              <div className="sm:col-span-2">
+                <span className="text-xs text-[var(--color-text-secondary)]">Flags</span>
+                <div className="mt-0.5 flex items-center gap-2">
+                  {schedule.suspended ? (
+                    <Badge variant="secondary" className="text-[10px]">
+                      Suspended
+                    </Badge>
+                  ) : null}
+                  {schedule.autoDelete ? (
+                    <Badge variant="secondary" className="text-[10px]">
+                      Auto-delete
+                    </Badge>
+                  ) : null}
+                  {schedule.keepAgents ? (
+                    <Badge variant="secondary" className="text-[10px]">
+                      Keep agents
+                    </Badge>
+                  ) : null}
+                  {!schedule.suspended && !schedule.autoDelete && !schedule.keepAgents && (
+                    <span className="text-sm text-[var(--color-text-secondary)]">--</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {/* Target agent */}
+              <div className="flex flex-col gap-1.5 sm:col-span-2">
+                <Label>Target Agent</Label>
+                <Select
+                  value={detailsDraft.agentName || "__new__"}
+                  onValueChange={(v) =>
+                    setDetailsDraft({
+                      ...detailsDraft,
+                      agentName: v === "__new__" ? "" : v,
+                    })
+                  }
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__new__">Create a new agent each run</SelectItem>
+                    {availableAgents.map((a) => (
+                      <SelectItem key={a.name} value={a.name}>
+                        {a.name}
+                        {a.namespace && a.namespace !== schedule.namespace ? ` (${a.namespace})` : ""}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-[11px] text-[var(--color-text-muted)]">
+                  Reference an existing agent, or leave on &quot;Create a new agent each run&quot; to use the template below.
+                </p>
+              </div>
+
+              {/* Timezone */}
+              <div className="flex flex-col gap-1.5">
+                <Label>Timezone</Label>
+                <input
+                  value={detailsDraft.timezone}
+                  onChange={(e) =>
+                    setDetailsDraft({ ...detailsDraft, timezone: e.target.value })
+                  }
+                  placeholder="UTC"
+                  className="h-9 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-brand-blue)]"
+                />
+              </div>
+
+              {/* Flags */}
+              <div className="flex flex-col gap-1.5">
+                <Label>Flags</Label>
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setDetailsDraft({ ...detailsDraft, suspended: !detailsDraft.suspended })
+                    }
+                    className={`text-xs px-2.5 py-1 rounded-full border transition-colors cursor-pointer ${
+                      detailsDraft.suspended
+                        ? "border-[var(--color-text)] bg-white/10 text-[var(--color-text)]"
+                        : "border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-hover)]"
+                    }`}
+                  >
+                    {detailsDraft.suspended && <Check className="inline size-2.5 mr-1" />}
+                    Suspended
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setDetailsDraft({ ...detailsDraft, autoDelete: !detailsDraft.autoDelete })
+                    }
+                    className={`text-xs px-2.5 py-1 rounded-full border transition-colors cursor-pointer ${
+                      detailsDraft.autoDelete
+                        ? "border-[var(--color-text)] bg-white/10 text-[var(--color-text)]"
+                        : "border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-hover)]"
+                    }`}
+                  >
+                    {detailsDraft.autoDelete && <Check className="inline size-2.5 mr-1" />}
+                    Delete after first run
+                  </button>
+                  {detailsDraft.autoDelete && (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setDetailsDraft({ ...detailsDraft, keepAgents: !detailsDraft.keepAgents })
+                      }
+                      className={`text-xs px-2.5 py-1 rounded-full border transition-colors cursor-pointer ${
+                        detailsDraft.keepAgents
+                          ? "border-[var(--color-text)] bg-white/10 text-[var(--color-text)]"
+                          : "border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-hover)]"
+                      }`}
+                    >
+                      {detailsDraft.keepAgents && <Check className="inline size-2.5 mr-1" />}
+                      Keep agents after deletion
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {/* Inline agent template — only when no agentName is targeted */}
+              {!detailsDraft.agentName.trim() && (
+                <>
+                  <div className="flex flex-col gap-1.5 sm:col-span-2">
+                    <div className="text-[11px] uppercase tracking-wider font-semibold text-[var(--color-text-muted)] pt-2 border-t border-[var(--color-border)]">
+                      Agent template (used to create a new agent each run)
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label>Model</Label>
+                    <Select
+                      value={detailsDraft.agentModel || "__default__"}
+                      onValueChange={(v) =>
+                        setDetailsDraft({
+                          ...detailsDraft,
+                          agentModel: v === "__default__" ? "" : v,
+                        })
+                      }
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__default__">Cluster default</SelectItem>
+                        {MODELS.map((m) => (
+                          <SelectItem key={m.value} value={m.value}>
+                            {m.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label>Lifecycle</Label>
+                    <Select
+                      value={detailsDraft.agentLifecycle}
+                      onValueChange={(v) =>
+                        v && setDetailsDraft({ ...detailsDraft, agentLifecycle: v })
+                      }
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {LIFECYCLES.map((l) => (
+                          <SelectItem key={l.value} value={l.value}>
+                            {l.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label>Role</Label>
+                    <input
+                      value={detailsDraft.agentRole}
+                      onChange={(e) =>
+                        setDetailsDraft({ ...detailsDraft, agentRole: e.target.value })
+                      }
+                      placeholder="worker"
+                      className="h-9 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-brand-blue)]"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label>Agent Template</Label>
+                    <input
+                      value={detailsDraft.agentTemplateRef}
+                      onChange={(e) =>
+                        setDetailsDraft({
+                          ...detailsDraft,
+                          agentTemplateRef: e.target.value,
+                        })
+                      }
+                      placeholder="default"
+                      className="h-9 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-brand-blue)]"
+                    />
+                  </div>
+                </>
+              )}
+            </div>
+          )}
         </section>
       </motion.div>
     </div>

--- a/komputer-ui/src/components/secrets/secret-cards.tsx
+++ b/komputer-ui/src/components/secrets/secret-cards.tsx
@@ -138,14 +138,12 @@ export function SecretCards({ secrets, onDelete, onUpdated }: SecretCardsProps) 
                     <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0 bg-amber-500/10">
                       <KeyRound className="w-3.5 h-3.5 text-amber-400" />
                     </div>
-                    <span className="text-[13px] font-semibold text-[var(--color-text)] truncate leading-tight flex-1 min-w-0">
+                    <span
+                      className="text-[13px] font-semibold text-[var(--color-text)] truncate leading-tight flex-1 min-w-0"
+                      title={secret.name}
+                    >
                       {secret.name}
                     </span>
-                    {!secret.managed && (
-                      <span className="inline-flex items-center text-[9px] tracking-wider px-1.5 py-0.5 rounded bg-[var(--color-surface-hover)] text-[var(--color-text-muted)] shrink-0 leading-none">
-                        external
-                      </span>
-                    )}
                     <div className="flex items-center gap-1 shrink-0">
                       <div onClick={(e) => e.stopPropagation()} className="opacity-0 group-hover:opacity-100 transition-opacity">
                         <ConfirmDialog
@@ -163,9 +161,16 @@ export function SecretCards({ secrets, onDelete, onUpdated }: SecretCardsProps) 
                   </div>
 
                   <div className="mt-2 min-h-[2.75rem]">
-                    <p className="text-[11px] text-[var(--color-text-secondary)]">
-                      {secret.keys.length} {secret.keys.length === 1 ? "key" : "keys"}
-                    </p>
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-[11px] text-[var(--color-text-secondary)]">
+                        {secret.keys.length} {secret.keys.length === 1 ? "key" : "keys"}
+                      </p>
+                      {!secret.managed && (
+                        <span className="inline-flex items-center text-[9px] tracking-wider px-1.5 py-0.5 rounded bg-[var(--color-surface-hover)] text-[var(--color-text-muted)] shrink-0 leading-none">
+                          external
+                        </span>
+                      )}
+                    </div>
                     {secret.agentName && (
                       <Link
                         href={`/agents/${secret.agentName}?namespace=${secret.namespace}`}

--- a/komputer-ui/src/components/shared/confirm-dialog.tsx
+++ b/komputer-ui/src/components/shared/confirm-dialog.tsx
@@ -16,6 +16,10 @@ type ConfirmDialogProps = {
   description: string;
   onConfirm: () => void;
   trigger: ReactNode;
+  /** Label for the confirm button. Defaults to "Delete". */
+  confirmLabel?: string;
+  /** Visual style of the confirm button. Defaults to "destructive". */
+  confirmVariant?: "destructive" | "primary" | "secondary";
 };
 
 export function ConfirmDialog({
@@ -23,6 +27,8 @@ export function ConfirmDialog({
   description,
   onConfirm,
   trigger,
+  confirmLabel = "Delete",
+  confirmVariant = "destructive",
 }: ConfirmDialogProps) {
   const [open, setOpen] = useState(false);
 
@@ -48,13 +54,13 @@ export function ConfirmDialog({
               Cancel
             </Button>
             <Button
-              variant="destructive"
+              variant={confirmVariant}
               onClick={() => {
                 onConfirm();
                 setOpen(false);
               }}
             >
-              Delete
+              {confirmLabel}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/komputer-ui/src/lib/api.ts
+++ b/komputer-ui/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   OfficeListResponse,
   ScheduleResponse,
   ScheduleListResponse,
+  PatchScheduleRequest,
   CreateAgentRequest,
   CreateScheduleRequest,
   AgentEvent,
@@ -131,7 +132,7 @@ export const createSchedule = (data: CreateScheduleRequest) =>
 export const deleteSchedule = (name: string, ns?: string) =>
   request<void>(`/schedules/${name}${ns ? `?namespace=${ns}` : ''}`, { method: 'DELETE' });
 
-export const patchSchedule = (name: string, data: { schedule?: string; instructions?: string }, ns?: string) =>
+export const patchSchedule = (name: string, data: PatchScheduleRequest, ns?: string) =>
   request<ScheduleResponse>(`/schedules/${name}${ns ? `?namespace=${ns}` : ''}`, { method: 'PATCH', body: JSON.stringify(data) });
 
 export const triggerSchedule = (name: string, ns?: string) =>

--- a/komputer-ui/src/lib/types.ts
+++ b/komputer-ui/src/lib/types.ts
@@ -65,6 +65,14 @@ export interface OfficeListResponse {
   offices: OfficeResponse[];
 }
 
+export interface ScheduleAgentSpec {
+  model?: string;
+  lifecycle?: string;
+  role?: string;
+  templateRef?: string;
+  secretRefs?: string[];
+}
+
 export interface ScheduleResponse {
   name: string;
   namespace: string;
@@ -73,6 +81,8 @@ export interface ScheduleResponse {
   timezone?: string;
   autoDelete?: boolean;
   keepAgents?: boolean;
+  suspended?: boolean;
+  agent?: ScheduleAgentSpec;
   phase: 'Active' | 'Suspended' | 'Error';
   agentName?: string;
   nextRunTime?: string;
@@ -86,6 +96,17 @@ export interface ScheduleResponse {
   lastRunTokens?: number;
   lastRunStatus?: string;
   createdAt: string;
+}
+
+export interface PatchScheduleRequest {
+  schedule?: string;
+  instructions?: string;
+  timezone?: string;
+  autoDelete?: boolean;
+  keepAgents?: boolean;
+  suspended?: boolean;
+  agentName?: string;
+  agent?: ScheduleAgentSpec;
 }
 
 export interface ScheduleListResponse {


### PR DESCRIPTION
## Summary
- API `PatchScheduleRequest` now covers `timezone`, `autoDelete`, `keepAgents`, `suspended`, `agentName`, and the inline `ScheduleAgentSpec` template; `PatchScheduleSpec` enforces the `AgentName`/`Agent` exclusivity baked into the CRD
- `ScheduleResponse` surfaces `suspended` and the inline agent template so the UI can render and edit them
- SDK regenerated (openapi.yaml + Go/Python/TS wrappers) — the `PatchSchedule` calls thread every new field
- CLI `komputer schedule update` (aliased `edit` / `patch`) accepts flags for every editable field, including `--model`, `--lifecycle`, `--role`, `--template-ref`, `--secret`
- UI schedule detail page: header `Suspend`/`Resume` toggle next to `Run now`, plus an editable Details section (Target Agent, Timezone, Suspended/AutoDelete/KeepAgents flags, and the inline Agent Template — auto-hidden when an existing agent is targeted)
- `ConfirmDialog` gains `confirmLabel` + `confirmVariant` props so the schedule's Run-now dialog reads **"Run now"** (primary) instead of **"Delete"** (destructive)

End-to-end PATCH round-trip verified locally (`{suspended:true}` → response `suspended:true, phase:Suspended`).

## Test plan
- [ ] CI green across API / CLI / Operator / UI / SDK
- [ ] Manual: edit timezone + flags + agent target on a schedule via UI
- [ ] Manual: `komputer schedule update <name> --suspended --timezone Europe/Berlin`
- [ ] Manual: confirm Run-now dialog button reads "Run now"

Generated with [Claude Code](https://claude.com/claude-code)
