### PR TITLE
fix(ui): thread namespace through outbound navigation + wake

### DIFF
--- a/komputer-ui/src/app/agents/[name]/page.tsx
+++ b/komputer-ui/src/app/agents/[name]/page.tsx
@@ -296,7 +296,9 @@ export default function AgentDetailPage() {
   const handleWake = async () => {
     if (!agentName) return;
     try {
-      await createAgent({ name: agentName, instructions: "wake" });
+      // Without namespace the API can't find the sleeping CR and falls
+      // through to creating a new "wake" agent in the default namespace.
+      await createAgent({ name: agentName, instructions: "wake", namespace: agentNs });
       fetchAgent();
     } catch {
       // Will be reflected in next poll

--- a/komputer-ui/src/components/costs/agent-task-breakdown.tsx
+++ b/komputer-ui/src/components/costs/agent-task-breakdown.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@/components/kit/select";
 import { getAgentCostBreakdown } from "@/lib/api";
+import { namespacedHref } from "@/lib/namespaced-href";
 import type { AgentResponse, CostBreakdownResponse, TaskBreakdown } from "@/lib/types";
 
 type SortKey = "index" | "costUSD" | "durationMs" | "inputTokens";
@@ -213,7 +214,10 @@ export function AgentTaskBreakdown({ agents }: { agents: AgentResponse[] }) {
                         if (task.completedAt) params.set("taskTo", task.completedAt);
                         // Pass event count so we fetch just enough + a small buffer
                         params.set("taskEvents", String(task.events?.length ?? 50));
-                        router.push(`/agents/${selectedAgent}?${params.toString()}`);
+                        const agentNs = agents.find((a) => a.name === selectedAgent)?.namespace;
+                        router.push(
+                          namespacedHref(`/agents/${selectedAgent}?${params.toString()}`, agentNs),
+                        );
                       }}
                       className={`flex items-center gap-3 rounded-md px-3 py-2 text-xs transition-colors cursor-pointer hover:bg-[var(--color-surface-hover)] ${
                         isMostExpensive

--- a/komputer-ui/src/components/schedules/create-schedule-modal.tsx
+++ b/komputer-ui/src/components/schedules/create-schedule-modal.tsx
@@ -27,6 +27,7 @@ import { NamespaceSelector } from "@/components/shared/namespace-selector";
 import { createSchedule, listAgents } from "@/lib/api";
 import type { CreateScheduleRequest } from "@/lib/types";
 import { LIFECYCLES } from "@/lib/constants";
+import { namespacedHref } from "@/lib/namespaced-href";
 
 type CreateScheduleModalProps = {
   open: boolean;
@@ -118,7 +119,7 @@ export function CreateScheduleModal({ open, onOpenChange, onCreated }: CreateSch
       resetForm();
       onOpenChange(false);
       onCreated?.();
-      router.push(`/schedules/${scheduleName}`);
+      router.push(namespacedHref(`/schedules/${scheduleName}`, namespace));
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to create schedule.");
     } finally {

--- a/komputer-ui/src/components/schedules/schedule-table.tsx
+++ b/komputer-ui/src/components/schedules/schedule-table.tsx
@@ -17,6 +17,7 @@ import { StatusBadge } from "@/components/shared/status-badge";
 import { CostBadge } from "@/components/shared/cost-badge";
 import { RelativeTime } from "@/components/shared/relative-time";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { namespacedHref } from "@/lib/namespaced-href";
 import { cronToHuman } from "@/lib/utils";
 import type { ScheduleResponse } from "@/lib/types";
 
@@ -61,7 +62,7 @@ export function ScheduleTable({ schedules, onDelete }: ScheduleTableProps) {
               <TableCell>
                 <div className="flex items-center gap-2">
                   <Link
-                    href={`/schedules/${schedule.name}`}
+                    href={namespacedHref(`/schedules/${schedule.name}`, schedule.namespace)}
                     className="font-medium text-[var(--color-brand-blue)] hover:underline"
                   >
                     {schedule.name}

--- a/komputer-ui/src/components/topology/node-types.tsx
+++ b/komputer-ui/src/components/topology/node-types.tsx
@@ -5,6 +5,7 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { useRouter } from "next/navigation";
 import { Building2, Clock } from "lucide-react";
 import { StatusBadge } from "@/components/shared/status-badge";
+import { namespacedHref } from "@/lib/namespaced-href";
 
 function TooltipRow({ label, value, color }: { label: string; value?: string | number; color?: string }) {
   if (!value && value !== 0) return null;
@@ -164,7 +165,7 @@ function OfficeNodeComponent({ data }: NodeProps) {
       className="relative cursor-pointer rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-5 py-3.5 transition-shadow hover:shadow-[0_4px_16px_rgba(var(--shadow-color),var(--shadow-strength)),inset_0_1px_0_var(--color-border-light)]"
       style={{ width: nodeWidth || 220 }}
       data-hovered={hovered || undefined}
-      onClick={() => router.push(`/offices/${label}`)}
+      onClick={() => router.push(namespacedHref(`/offices/${label}`, namespace))}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
@@ -234,7 +235,7 @@ function ScheduleNodeComponent({ data }: NodeProps) {
       className="relative cursor-pointer rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 shadow-md transition-shadow hover:shadow-lg"
       style={{ width: nodeWidth || 170 }}
       data-hovered={hovered || undefined}
-      onClick={() => router.push(`/schedules/${label}`)}
+      onClick={() => router.push(namespacedHref(`/schedules/${label}`, namespace))}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/komputer-ui/src/lib/namespaced-href.ts
+++ b/komputer-ui/src/lib/namespaced-href.ts
@@ -1,0 +1,18 @@
+/**
+ * Build a path that carries the namespace query param.
+ *
+ * Most resource pages (agents, schedules, offices, squads) read namespace
+ * from `?namespace=…`. Forgetting it sends users to the wrong record (or a
+ * 404). Use this helper for every outbound link or programmatic navigation
+ * to those pages.
+ *
+ * If `namespace` is undefined or "default", the path is returned unchanged —
+ * "default" is the implicit fallback in the API and adding it adds noise.
+ *
+ * If the path already contains a query string, the namespace is merged in.
+ */
+export function namespacedHref(path: string, namespace?: string | null): string {
+  if (!namespace || namespace === "default") return path;
+  const sep = path.includes("?") ? "&" : "?";
+  return `${path}${sep}namespace=${encodeURIComponent(namespace)}`;
+}


### PR DESCRIPTION
## Summary

Three bugs reported, all the same root cause: outbound UI navigation was dropping the `namespace` query param, so the destination page loaded a different namespace (or 404'd, or silently created a duplicate CR).

### Bug fixes

- **Cost page → agent chat** ([agent-task-breakdown.tsx](komputer-ui/src/components/costs/agent-task-breakdown.tsx)): clicking a task row built `/agents/${name}?taskFrom=…` with no namespace, opening the wrong agent. Now looks up the agent's namespace from the agent list and threads it.
- **Create schedule → detail page** ([create-schedule-modal.tsx](komputer-ui/src/components/schedules/create-schedule-modal.tsx)): the post-create redirect dropped namespace, so the detail page couldn't fetch the schedule. Fixed.
- **Run-now / schedule "not found"**: transitive — once the create redirect carries namespace, the detail page reads it correctly and the trigger call works.
- **Wake duplicates** ([page.tsx](komputer-ui/src/app/agents/[name]/page.tsx)): `handleWake` called `createAgent` without a namespace. The API couldn't find the sleeping CR and fell through to creating a fresh agent in `default` — the duplicate phantom in the screenshot. Now passes `agentNs`.

### Helper

Introduces `namespacedHref(path, namespace)` ([namespaced-href.ts](komputer-ui/src/lib/namespaced-href.ts)) — returns the path unchanged when namespace is missing or `"default"`, otherwise appends `?namespace=…` (merging into any existing query string). Used at every outbound nav site so new code defaults to namespace-aware navigation.

### Bonus

Same shape of leak found and fixed at the topology graph office/schedule nodes and the (currently unused) schedule-table row link.

## Test plan
- [ ] CI green
- [ ] Manual: from cost page, click a task → lands on the correct agent
- [ ] Manual: create a schedule in a non-default namespace → detail page loads, Run-now works
- [ ] Manual: wake a sleeping agent in a non-default namespace → no duplicate appears in the agent list

Generated with [Claude Code](https://claude.com/claude-code)
