### PR TITLE
fix(ui): disable Compact button while agent is Sleeping

### DIFF
--- a/komputer-ui/src/app/agents/[name]/page.tsx
+++ b/komputer-ui/src/app/agents/[name]/page.tsx
@@ -468,8 +468,12 @@ export default function AgentDetailPage() {
                   variant="secondary"
                   size="sm"
                   onClick={handleCompact}
-                  disabled={compactBusy}
-                  title="Compact conversation history. Queues /compact as a follow-up message — runs as soon as the current turn finishes (or immediately if the agent is idle and responsive)."
+                  disabled={compactBusy || agent.status === "Sleeping"}
+                  title={
+                    agent.status === "Sleeping"
+                      ? "Wake the agent before compacting — there is no running pod to receive the request."
+                      : "Compact conversation history. Queues /compact as a follow-up message — runs as soon as the current turn finishes (or immediately if the agent is idle and responsive)."
+                  }
                   className="border-amber-500/40 bg-amber-500/10 text-amber-300 hover:bg-amber-500/15 hover:border-amber-500/55 hover:text-amber-200"
                 >
                   <Layers className="size-3" data-icon="inline-start" />


### PR DESCRIPTION
## Summary

Compacting a sleeping agent surfaced a raw `"agent has no running pod"` error inline on the button (since the agent pod is gone in Sleep lifecycle). Disable the button when `status === "Sleeping"` and explain in the tooltip that the agent needs to be woken first.

## Test plan
- [ ] CI green
- [ ] Manual: open a sleeping agent's page → Compact button is disabled, tooltip explains why
- [ ] Manual: wake the agent → Compact button re-enables

Generated with [Claude Code](https://claude.com/claude-code)
