### PR TITLE
fix(agent): keep session transcripts indefinitely

### DIFF
--- a/komputer-agent/agent.py
+++ b/komputer-agent/agent.py
@@ -156,6 +156,9 @@ async def run_agent(instructions: str, model: str, publisher, system_prompt: str
         tools=["Bash", "WebSearch", "WebFetch", "Read", "Write", "Edit", "Glob", "Grep", "Skill"],
         allowed_tools=["Bash", "WebSearch", "WebFetch", "Read", "Write", "Edit", "Glob", "Grep", "Skill"],
         setting_sources=["user", "project"],
+        # Keep session transcripts effectively forever (CLI rejects 0; min is 1 day).
+        # Without this the SDK's daily cleanup deletes JSONLs idle for >30 days.
+        settings='{"cleanupPeriodDays": 36500}',
         permission_mode="bypassPermissions",
         model=model,
         cwd="/workspace",


### PR DESCRIPTION
## Summary
The Claude Agent SDK's daily retention sweep deletes session JSONL transcripts whose mtime is older than `cleanupPeriodDays` (default 30 days). Agents that slept for over a month silently lost their transcript files on the next wake.

This passes `cleanupPeriodDays: 36500` (~100 years) as inline `--settings` via `ClaudeAgentOptions` — command-line settings outrank user/project settings files, so no settings.json provisioning is needed in the pod. The CLI rejects `0`, so a large value is the supported way to get effectively infinite retention.

## Changes
- `komputer-agent/agent.py`: add `settings='{"cleanupPeriodDays": 36500}'` to `ClaudeAgentOptions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)