### PR TITLE
fix(api): reject invalid Bedrock model identifiers at create time

### DIFF
--- a/helm/komputer-ai/templates/komputer-api/deployment.yaml
+++ b/helm/komputer-ai/templates/komputer-api/deployment.yaml
@@ -39,6 +39,15 @@ spec:
           value: {{ .Values.config.redis.streamPrefix }}
         - name: KOMPUTER_METRICS_PER_AGENT
           value: {{ .Values.metrics.perAgentLabels | quote }}
+        {{- if .Values.bedrock.enabled }}
+        # Lets the API reject Anthropic friendly model names (e.g. claude-sonnet-4-6)
+        # at agent-create time, since agents run against Bedrock and need a
+        # region-prefixed inference-profile ID instead.
+        - name: CLAUDE_CODE_USE_BEDROCK
+          value: "1"
+        - name: AWS_REGION
+          value: {{ .Values.bedrock.region | quote }}
+        {{- end }}
         {{- if .Values.api.oauth.callbackUrl }}
         - name: OAUTH_CALLBACK_URL
           value: {{ .Values.api.oauth.callbackUrl | quote }}

--- a/komputer-api/handler_agents.go
+++ b/komputer-api/handler_agents.go
@@ -278,6 +278,14 @@ func createOrTriggerAgent(k8s *K8sClient) gin.HandlerFunc {
 			return
 		}
 
+		// On Bedrock, reject friendly model names before they reach the SDK. A new
+		// agent requires a valid model (empty would fall back to a friendly default);
+		// wake/forward only reject a non-empty bad override (empty = keep existing).
+		if err := validateBedrockModel(req.Model, existing == nil); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
 		if existing != nil {
 			// Wake-up flow for sleeping agents
 			if existing.Status.Phase == komputerv1alpha1.AgentPhaseSleeping {
@@ -878,6 +886,13 @@ func patchAgent(k8s *K8sClient) gin.HandlerFunc {
 		if req.Model == nil && req.Lifecycle == nil && req.Instructions == nil && req.TemplateRef == nil && req.SecretRefs == nil && req.Memories == nil && req.Skills == nil && req.Connectors == nil && req.SystemPrompt == nil && req.Priority == nil && req.PodSpec == nil && req.Storage == nil && len(req.Labels) == 0 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no fields to update"})
 			return
+		}
+		// On Bedrock, reject a friendly model override before it reaches the SDK.
+		if req.Model != nil {
+			if err := validateBedrockModel(*req.Model, false); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
 		}
 
 		var nonFatalErrors []string

--- a/komputer-api/handler_squads.go
+++ b/komputer-api/handler_squads.go
@@ -203,6 +203,18 @@ func createSquad(k8s *K8sClient) gin.HandlerFunc {
 			ns = resolveNamespace(c, k8s)
 		}
 
+		// On Bedrock, reject friendly model names on inline member specs before
+		// they reach the SDK. Inline specs are new agents, so a model is required.
+		for _, m := range req.Members {
+			if m.Spec == nil {
+				continue
+			}
+			if err := validateBedrockModel(m.Spec.Model, true); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+		}
+
 		// Block team-up of running agents — the existing solo pod must be removed first.
 		// Sleeping the agent stops its pod (PVC kept) so the squad pod can adopt it cleanly.
 		for _, m := range req.Members {
@@ -328,6 +340,16 @@ func patchSquad(k8s *K8sClient) gin.HandlerFunc {
 		if req.Members == nil && req.OrphanTTL == nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no fields to update"})
 			return
+		}
+		// On Bedrock, reject friendly model names on inline member specs.
+		for _, m := range req.Members {
+			if m.Spec == nil {
+				continue
+			}
+			if err := validateBedrockModel(m.Spec.Model, true); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
 		}
 
 		// Retry once on 409 conflict.
@@ -489,6 +511,13 @@ func addSquadMember(k8s *K8sClient) gin.HandlerFunc {
 		if req.Ref != nil && req.Spec != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "exactly one of ref or spec must be set"})
 			return
+		}
+		// On Bedrock, reject a friendly model name on an inline member spec.
+		if req.Spec != nil {
+			if err := validateBedrockModel(req.Spec.Model, true); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
 		}
 
 		newMember := komputerv1alpha1.KomputerSquadMember{

--- a/komputer-api/validate_model.go
+++ b/komputer-api/validate_model.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// bedrockModelRe matches a region-prefixed Bedrock cross-region inference-profile
+// ID for Claude, e.g. "us.anthropic.claude-sonnet-4-6". The region prefix
+// (us/eu/apac/us-gov) is what Bedrock requires and what distinguishes a real
+// Bedrock identifier from an Anthropic API friendly name like "claude-sonnet-4-6".
+var bedrockModelRe = regexp.MustCompile(`^(us|eu|apac|us-gov)\.anthropic\.`)
+
+// isValidBedrockModel reports whether model is a usable Bedrock identifier:
+// a region-prefixed inference-profile ID or a full Bedrock ARN.
+func isValidBedrockModel(model string) bool {
+	return strings.HasPrefix(model, "arn:aws:bedrock:") || bedrockModelRe.MatchString(model)
+}
+
+// validateBedrockModel rejects Anthropic API friendly model names (e.g.
+// "claude-sonnet-4-6") when the API runs against AWS Bedrock, where the Claude
+// SDK needs a region-prefixed inference-profile ID or an ARN. Returning a
+// human-actionable error here means manager agents see it via the create_agent
+// MCP tool response and self-correct, instead of spawning a sub-agent that fails
+// at runtime with "400 The provided model identifier is invalid".
+//
+// It is a no-op on non-Bedrock deployments (friendly names are correct there).
+// required=true also rejects an empty model, used on the new-agent create path
+// where an empty model would otherwise fall back to a friendly default that
+// Bedrock rejects; wake/patch paths pass required=false (empty = "no change").
+func validateBedrockModel(model string, required bool) error {
+	if os.Getenv("CLAUDE_CODE_USE_BEDROCK") == "" {
+		return nil
+	}
+	if model == "" {
+		if required {
+			return fmt.Errorf("model is required on AWS Bedrock: pass a region-prefixed inference-profile ID like %q or a full ARN", bedrockExampleModel())
+		}
+		return nil
+	}
+	if isValidBedrockModel(model) {
+		return nil
+	}
+	return fmt.Errorf("invalid Bedrock model %q: pass a region-prefixed inference-profile ID like %q or a full ARN, not an Anthropic API name", model, bedrockExampleModel())
+}
+
+// bedrockExampleModel returns an example inference-profile ID using the region
+// prefix derived from AWS_REGION, so error messages give actionable guidance.
+func bedrockExampleModel() string {
+	prefix := "us"
+	region := os.Getenv("AWS_REGION")
+	switch {
+	case strings.HasPrefix(region, "us-gov-"):
+		prefix = "us-gov"
+	case strings.HasPrefix(region, "eu-"):
+		prefix = "eu"
+	case strings.HasPrefix(region, "ap-"):
+		prefix = "apac"
+	}
+	return prefix + ".anthropic.claude-sonnet-4-6"
+}

--- a/komputer-api/validate_model_test.go
+++ b/komputer-api/validate_model_test.go
@@ -1,0 +1,74 @@
+package main
+
+import "testing"
+
+// TestValidateBedrockModel verifies that friendly Anthropic model names are
+// rejected when the deployment runs against AWS Bedrock (where the SDK needs a
+// region-prefixed inference-profile ID or an ARN), while valid Bedrock IDs and
+// any model on non-Bedrock deployments pass through.
+func TestValidateBedrockModel(t *testing.T) {
+	cases := []struct {
+		name     string
+		bedrock  bool
+		region   string
+		model    string
+		required bool
+		wantErr  bool
+	}{
+		// Non-Bedrock: friendly names are correct, never rejected.
+		{"non-bedrock friendly name", false, "", "claude-sonnet-4-6", false, false},
+		{"non-bedrock empty required", false, "", "", true, false},
+
+		// Bedrock: friendly names are the bug — reject them.
+		{"bedrock friendly name", true, "us-east-1", "claude-sonnet-4-6", false, true},
+		{"bedrock tier alias", true, "us-east-1", "sonnet", false, true},
+		{"bedrock opus friendly", true, "eu-west-1", "claude-opus-4-7", true, true},
+
+		// Bedrock: valid identifiers pass.
+		{"bedrock us inference profile", true, "us-east-1", "us.anthropic.claude-sonnet-4-6", false, false},
+		{"bedrock eu inference profile", true, "eu-west-1", "eu.anthropic.claude-sonnet-4-5-20250929-v1:0", false, false},
+		{"bedrock apac inference profile", true, "ap-southeast-1", "apac.anthropic.claude-sonnet-4-6", false, false},
+		{"bedrock arn", true, "us-east-1", "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6", false, false},
+
+		// Bedrock empty: rejected only when the model is required (new agent).
+		{"bedrock empty required", true, "us-east-1", "", true, true},
+		{"bedrock empty optional", true, "us-east-1", "", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.bedrock {
+				t.Setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+			} else {
+				t.Setenv("CLAUDE_CODE_USE_BEDROCK", "")
+			}
+			t.Setenv("AWS_REGION", tc.region)
+
+			err := validateBedrockModel(tc.model, tc.required)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateBedrockModel(%q, required=%v) error = %v, wantErr = %v", tc.model, tc.required, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestBedrockExampleRegionPrefix verifies the example model ID in error messages
+// uses the correct region prefix so the guidance is actionable.
+func TestBedrockExampleRegionPrefix(t *testing.T) {
+	cases := map[string]string{
+		"us-east-1":      "us.",
+		"eu-west-1":      "eu.",
+		"ap-southeast-1": "apac.",
+		"us-gov-east-1":  "us-gov.",
+		"":               "us.",
+	}
+	for region, wantPrefix := range cases {
+		t.Run(region, func(t *testing.T) {
+			t.Setenv("AWS_REGION", region)
+			got := bedrockExampleModel()
+			if len(got) < len(wantPrefix) || got[:len(wantPrefix)] != wantPrefix {
+				t.Fatalf("bedrockExampleModel() for region %q = %q, want prefix %q", region, got, wantPrefix)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

On AWS Bedrock, a manager agent that creates a sub-agent with an Anthropic *friendly* model name (e.g. `claude-sonnet-4-6`) produces a sub-agent that fails at runtime with:

```
API Error (claude-sonnet-4-6): 400 The provided model identifier is invalid.. Try switching to eu.anthropic.claude-sonnet-4-5-20250929-v1:0.
```

**Root cause:** the model identifier was never validated anywhere in the stack. The system trusted the LLM manager to emit a perfect region-prefixed Bedrock inference-profile ID (the only guardrail was one line of guidance in `manager.md`). LLMs follow that unreliably, so it failed repeatedly.

## Fix

Validate the model **at the API boundary** (chosen over a friendly→Bedrock translation layer to keep model selection explicit and avoid maintaining a mapping table):

- New helper `validateBedrockModel` — a valid Bedrock model starts with `arn:aws:bedrock:` or matches `^(us|eu|apac|us-gov)\.anthropic\.`. Complete no-op on non-Bedrock deployments.
- Rejects friendly names with an actionable 400 that includes a region-derived example. The error is surfaced verbatim to manager agents via the `create_agent` MCP tool response, so they **self-correct in-loop** instead of spawning a broken agent.
- Applied at every entry point a model enters from a request: create/wake (`createOrTriggerAgent`), `patchAgent`, `createSquad`, `patchSquad`, `addSquadMember`.
- API made Bedrock-aware via helm: `CLAUDE_CODE_USE_BEDROCK`/`AWS_REGION` injected into the API deployment, gated on `bedrock.enabled`.

## Behavior notes

- New-agent creation on Bedrock now requires an explicit valid model — the built-in default `claude-sonnet-4-6` is itself invalid on Bedrock, so omitting a model is rejected with guidance rather than silently creating a broken agent.
- Bare foundation IDs (`anthropic.claude-...` without a region prefix) are rejected by design (newer Claude models on Bedrock require inference profiles); the ARN form is the escape hatch.

## Testing

- `go build ./...` ✓
- Full API test suite ✓; new table tests cover friendly-name rejection, region-prefixed/ARN acceptance, empty-model required vs optional, and region→prefix derivation.
- `helm template` renders the env when `bedrock.enabled=true`, omits it when disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)