### PR TITLE
feat: retry transient agent HTTP requests + create_connector manager tool

### DIFF
--- a/komputer-agent/manager_tools.py
+++ b/komputer-agent/manager_tools.py
@@ -642,6 +642,54 @@ async def get_connector(args):
     return await _request("GET", f"/api/v1/connectors/{name}")
 
 
+@tool(
+    name="create_connector",
+    description="Create a connector (KomputerConnector) pointing to a remote MCP server, so its tools can be attached to agents. Use list_connector_templates first to find the right service and URL. Supports token/header auth (provide a token and it's stored in a secret automatically) or no auth. OAuth connectors must be set up by a human via the UI/CLI — they need a browser flow.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Connector name (lowercase, e.g. 'github')."},
+            "service": {"type": "string", "description": "Service identifier (e.g. 'github', 'slack', 'linear')."},
+            "url": {"type": "string", "description": "Remote MCP server endpoint URL."},
+            "token": {"type": "string", "description": "Auth token. If provided, it's stored in a managed secret and referenced by the connector. Omit for connectors that need no auth."},
+            "header_name": {"type": "string", "description": "Custom header name for the token (e.g. 'X-Api-Key'). When set, auth uses this header verbatim instead of 'Authorization: Bearer'."},
+            "display_name": {"type": "string", "description": "Human-friendly name shown in the UI."},
+        },
+        "required": ["name", "service", "url"],
+    },
+)
+async def create_connector(args):
+    name = _sanitize_name(args["name"])
+    token = args.get("token")
+    header_name = (args.get("header_name") or "").strip()
+
+    payload = {
+        "name": name,
+        "service": args["service"],
+        "url": args["url"],
+        "namespace": NAMESPACE,
+        "authType": "header" if header_name else ("token" if token else "none"),
+    }
+    if header_name:
+        payload["headerName"] = header_name
+    if args.get("display_name"):
+        payload["displayName"] = args["display_name"]
+
+    # A token is stored in its own managed secret, then referenced by the connector.
+    if token:
+        secret_name = f"{name}-credentials"
+        secret_result = await _request(
+            "POST", "/api/v1/secrets", timeout=30,
+            json={"name": secret_name, "data": {"token": token}, "namespace": NAMESPACE},
+        )
+        if secret_result.get("isError"):
+            return secret_result
+        payload["authSecretName"] = secret_name
+        payload["authSecretKey"] = "token"
+
+    return await _request("POST", "/api/v1/connectors", timeout=30, json=payload)
+
+
 async def _agent_list_field_patch(agent_name, field_name, mutator):
     """Helper: GET agent, mutate one of its list fields, PATCH it back.
 
@@ -1331,5 +1379,5 @@ def create_manager_server():
     """Create the MCP server with manager orchestration tools."""
     return create_sdk_mcp_server(
         name="komputer",
-        tools=[create_agent, schedule_agent, get_agent_status, get_agent_events, cancel_agent, compact_agent, delete_agent, delete_schedule, trigger_schedule, list_schedules, get_schedule, update_schedule, create_memory, attach_memory, create_skill, attach_skill, update_agent, sleep_agent, wake_agent, list_agents, patch_agent, get_agent, list_connectors, list_connector_templates, get_connector, attach_connector, detach_connector, list_secrets, create_secret, delete_secret, attach_secret, detach_secret, list_skills, get_skill, update_skill, delete_skill, detach_skill, list_memories, get_memory, update_memory, delete_memory, detach_memory, list_namespaces, list_templates, create_squad, add_to_squad, remove_from_squad, delete_squad, list_squads],
+        tools=[create_agent, schedule_agent, get_agent_status, get_agent_events, cancel_agent, compact_agent, delete_agent, delete_schedule, trigger_schedule, list_schedules, get_schedule, update_schedule, create_memory, attach_memory, create_skill, attach_skill, update_agent, sleep_agent, wake_agent, list_agents, patch_agent, get_agent, list_connectors, list_connector_templates, get_connector, create_connector, attach_connector, detach_connector, list_secrets, create_secret, delete_secret, attach_secret, detach_secret, list_skills, get_skill, update_skill, delete_skill, detach_skill, list_memories, get_memory, update_memory, delete_memory, detach_memory, list_namespaces, list_templates, create_squad, add_to_squad, remove_from_squad, delete_squad, list_squads],
     )

--- a/komputer-api/agent_http.go
+++ b/komputer-api/agent_http.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// agentRetryBackoff is the retry policy for direct HTTP calls to agent pods.
+// Transient failures (connection refused while the pod is still starting, per-attempt
+// timeouts, 5xx) are retried with jittered exponential backoff. Semantic 4xx responses
+// (e.g. 409 "agent busy") are returned immediately and never retried.
+var agentRetryBackoff = wait.Backoff{
+	Steps:    4,                      // up to 4 attempts total
+	Duration: 200 * time.Millisecond, // first backoff delay
+	Factor:   2.0,                    // 200ms → 400ms → 800ms
+	Jitter:   0.2,                    // ±20% to avoid synchronized retries
+	Cap:      2 * time.Second,
+}
+
+// doAgentRequest performs an HTTP request to an agent pod, retrying transient failures
+// with exponential backoff. Each attempt runs under its own perAttemptTimeout derived
+// from ctx; the retry loop stops immediately if ctx is cancelled. It returns the
+// response body and the final HTTP status code (0 if no response was received).
+func (k *K8sClient) doAgentRequest(ctx context.Context, method, url, body string, perAttemptTimeout time.Duration) ([]byte, int, error) {
+	var (
+		respBody []byte
+		status   int
+		lastErr  error
+		attempt  int
+	)
+
+	err := wait.ExponentialBackoffWithContext(ctx, agentRetryBackoff, func(ctx context.Context) (bool, error) {
+		attempt++
+		b, s, retryable, err := k.tryAgentRequest(ctx, method, url, body, perAttemptTimeout)
+		respBody, status = b, s
+		if err == nil {
+			lastErr = nil
+			return true, nil // success
+		}
+		lastErr = err
+		if !retryable {
+			return false, err // non-retryable (e.g. 4xx): stop and surface the error
+		}
+		Logger.Warnw("retrying agent request", "attempt", attempt, "method", method, "url", url, "error", err)
+		return false, nil // retryable: let backoff sleep, then try again
+	})
+
+	if err != nil {
+		// On a non-retryable failure ExponentialBackoff returns our error directly; on
+		// exhausted retries or context cancellation it returns its own sentinel — in
+		// every case lastErr holds the most informative message.
+		if lastErr != nil {
+			return respBody, status, lastErr
+		}
+		return respBody, status, err
+	}
+	return respBody, status, nil
+}
+
+// tryAgentRequest performs a single HTTP attempt. It reports whether a failure is
+// retryable: transport errors and 5xx responses are retryable; 4xx responses are not.
+func (k *K8sClient) tryAgentRequest(ctx context.Context, method, url, body string, perAttemptTimeout time.Duration) (respBody []byte, status int, retryable bool, err error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
+	defer cancel()
+
+	var reqBody io.Reader
+	if body != "" {
+		reqBody = strings.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(attemptCtx, method, url, reqBody)
+	if err != nil {
+		return nil, 0, false, err // malformed request: not retryable
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		// A cancelled or expired parent context is terminal; a per-attempt timeout or
+		// transport error is transient and worth another attempt.
+		if ctx.Err() != nil {
+			return nil, 0, false, err
+		}
+		return nil, 0, true, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ = io.ReadAll(resp.Body)
+	if resp.StatusCode >= 500 {
+		return respBody, resp.StatusCode, true, fmt.Errorf("agent returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return respBody, resp.StatusCode, false, fmt.Errorf("agent returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+	return respBody, resp.StatusCode, false, nil
+}

--- a/komputer-api/agent_http_test.go
+++ b/komputer-api/agent_http_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// initialize the global Logger once so the retry-warning path does not nil-panic.
+func init() { InitLogger() }
+
+func TestDoAgentRequest_RetriesTransientThenSucceeds(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	k := &K8sClient{}
+	body, status, err := k.doAgentRequest(context.Background(), http.MethodGet, srv.URL, "", 2*time.Second)
+	if err != nil {
+		t.Fatalf("expected success after retries, got error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", status)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("expected body %q, got %q", "ok", string(body))
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Fatalf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestDoAgentRequest_DoesNotRetry4xx(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte("agent busy"))
+	}))
+	defer srv.Close()
+
+	k := &K8sClient{}
+	_, status, err := k.doAgentRequest(context.Background(), http.MethodPost, srv.URL, "{}", 2*time.Second)
+	if err == nil {
+		t.Fatal("expected error for 409 response, got nil")
+	}
+	if status != http.StatusConflict {
+		t.Fatalf("expected status 409, got %d", status)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected exactly 1 attempt (no retry on 4xx), got %d", got)
+	}
+}
+
+func TestDoAgentRequest_ExhaustsRetriesOnPersistentTransient(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	k := &K8sClient{}
+	_, _, err := k.doAgentRequest(context.Background(), http.MethodGet, srv.URL, "", 2*time.Second)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	if got := atomic.LoadInt32(&attempts); int(got) != agentRetryBackoff.Steps {
+		t.Fatalf("expected %d attempts, got %d", agentRetryBackoff.Steps, got)
+	}
+}
+
+func TestDoAgentRequest_StopsOnContextCancellation(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel during the first backoff sleep, before retries are exhausted.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	k := &K8sClient{}
+	_, _, err := k.doAgentRequest(ctx, http.MethodGet, srv.URL, "", 2*time.Second)
+	if err == nil {
+		t.Fatal("expected error on context cancellation, got nil")
+	}
+	if got := atomic.LoadInt32(&attempts); int(got) >= agentRetryBackoff.Steps {
+		t.Fatalf("expected fewer than %d attempts due to cancellation, got %d", agentRetryBackoff.Steps, got)
+	}
+}

--- a/komputer-api/k8s.go
+++ b/komputer-api/k8s.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -19,8 +18,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -536,41 +535,16 @@ func (k *K8sClient) ForwardTaskToAgent(ctx context.Context, ns, podName, agentNa
 	return result.ContextWindow, nil
 }
 
-// postToAgent makes an HTTP POST to an agent via its per-agent K8s Service.
+// postToAgent makes an HTTP POST to an agent via its per-agent K8s Service, retrying
+// transient failures with backoff (see doAgentRequest).
 // When LOCAL=true, skips HTTP entirely to force exec fallback (no in-cluster DNS).
 func (k *K8sClient) postToAgent(ctx context.Context, ns, agentName, path, body string) error {
 	if os.Getenv("LOCAL") == "true" {
 		return fmt.Errorf("LOCAL mode: skipping direct pod HTTP")
 	}
 	url := agentHTTPBase(ns, agentName) + path
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	var reqBody io.Reader
-	if body != "" {
-		reqBody = strings.NewReader(body)
-	}
-
-	req, err := http.NewRequestWithContext(timeoutCtx, http.MethodPost, url, reqBody)
-	if err != nil {
-		return err
-	}
-	if body != "" {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("agent returned status %d: %s", resp.StatusCode, string(respBody))
-	}
-	return nil
+	_, _, err := k.doAgentRequest(ctx, http.MethodPost, url, body, 3*time.Second)
+	return err
 }
 
 // execInPod runs a command inside a pod's first container.
@@ -1024,69 +998,27 @@ func (k *K8sClient) PatchAgentSpec(ctx context.Context, ns, agentName string, mo
 	return k.client.Patch(ctx, agent, client.MergeFrom(original))
 }
 
-// getFromAgent makes an HTTP GET to an agent via its per-agent K8s Service.
+// getFromAgent makes an HTTP GET to an agent via its per-agent K8s Service, retrying
+// transient failures with backoff (see doAgentRequest).
 func (k *K8sClient) getFromAgent(ctx context.Context, ns, agentName, path string) ([]byte, error) {
 	if os.Getenv("LOCAL") == "true" {
 		return nil, fmt.Errorf("LOCAL mode: skipping direct pod HTTP")
 	}
 	url := agentHTTPBase(ns, agentName) + path
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(timeoutCtx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("agent returned status %d: %s", resp.StatusCode, string(respBody))
-	}
-	return respBody, nil
+	respBody, _, err := k.doAgentRequest(ctx, http.MethodGet, url, "", 5*time.Second)
+	return respBody, err
 }
 
 // postToAgentWithResponse makes an HTTP POST to an agent via its per-agent K8s Service
-// and returns the response body.
+// and returns the response body, retrying transient failures with backoff (see
+// doAgentRequest).
 func (k *K8sClient) postToAgentWithResponse(ctx context.Context, ns, agentName, path, body string) ([]byte, error) {
 	if os.Getenv("LOCAL") == "true" {
 		return nil, fmt.Errorf("LOCAL mode: skipping direct pod HTTP")
 	}
 	url := agentHTTPBase(ns, agentName) + path
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	var reqBody io.Reader
-	if body != "" {
-		reqBody = strings.NewReader(body)
-	}
-
-	req, err := http.NewRequestWithContext(timeoutCtx, http.MethodPost, url, reqBody)
-	if err != nil {
-		return nil, err
-	}
-	if body != "" {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		return nil, fmt.Errorf("agent returned status %d: %s", resp.StatusCode, string(respBody))
-	}
-	return respBody, nil
+	respBody, _, err := k.doAgentRequest(ctx, http.MethodPost, url, body, 3*time.Second)
+	return respBody, err
 }
 
 // ApplyAgentConfig sends a config update to the agent's FastAPI /config endpoint,

--- a/komputer-api/prompts/manager.md
+++ b/komputer-api/prompts/manager.md
@@ -85,6 +85,6 @@ Your context window is finite — protect it aggressively. Every tool call outpu
 - If the task is simple enough for one agent, just do it yourself
 
 ## Self-Management
-You can directly manage the platform's resources without asking a human: agents (sleep/wake/list/get/update/cancel/delete), connectors (list/attach/detach), secrets (list/create/attach/detach/delete), skills and memories (full CRUD + attach/detach), schedules (list/get/update/delete), and discovery (list_namespaces, list_templates). Use these to set up sub-agents fully configured for their task — connectors, secrets, skills attached — before sending instructions.
+You can directly manage the platform's resources without asking a human: agents (sleep/wake/list/get/update/cancel/delete), connectors (list/get/create/attach/detach), secrets (list/create/attach/detach/delete), skills and memories (full CRUD + attach/detach), schedules (list/get/update/delete), and discovery (list_namespaces, list_templates). Use these to set up sub-agents fully configured for their task — connectors, secrets, skills attached — before sending instructions.
 
 Use `labels` (a key=value map on `create_agent`/`patch_agent`) to tag agents for grouping and filtering — e.g. `team=core`, `project=demo`. The `komputer.ai/*` prefix is reserved.


### PR DESCRIPTION
## Summary

Two changes:

### 1. Retry mechanism for API → agent HTTP calls
`komputer-api` contacts each agent pod over HTTP via a per-agent K8s Service. The three low-level senders (`postToAgent`, `postToAgentWithResponse`, `getFromAgent`) each made a **single** attempt and fell straight to a `kubectl exec` fallback on any error — which doesn't help the common race where a task is forwarded before the agent's HTTP server is ready.

- New `komputer-api/agent_http.go`: shared `doAgentRequest` core built on `wait.ExponentialBackoffWithContext` (already a transitive dep via controller-runtime — no new go.mod entry).
  - 4 attempts, 200ms→400ms→800ms with ±20% jitter, 2s cap.
  - Retries transport errors and 5xx; returns 4xx (e.g. 409 "agent busy") immediately; stops on parent-context cancellation.
  - One `Warnw` log per retry.
- The three senders become thin wrappers that delegate to it (keeping their `LOCAL=true` short-circuit), removing ~70 lines of duplicated HTTP plumbing.
- The `kubectl exec` fallback is **preserved** and now only fires after retries are exhausted.

### 2. `create_connector` manager MCP tool
Lets manager agents create a `KomputerConnector` pointing at a remote MCP server (token/header/no-auth) without a human. A provided token is stored in a managed secret and referenced by the connector; OAuth still requires the human UI flow. Tool registered + documented in the manager prompt.

## Testing
New `komputer-api/agent_http_test.go` (TDD, each test watched fail first):
1. 503×2 then 200 → succeeds after 3 attempts
2. 409 → returns immediately, exactly 1 attempt (no retry on 4xx)
3. Persistent 502 → errors after exactly `Steps` attempts
4. Cancelled context → stops early

`go build ./...`, `go test ./...`, and `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)